### PR TITLE
Add security and supply chain workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: '0 8 * * 1'
+
+jobs:
+  analyze:
+    name: CodeQL Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile=false
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+      - name: Build project
+        run: pnpm -w -r build
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,27 @@
+name: dependency-review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Review dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          deny-licenses: |
+            AGPL-1.0-only
+            AGPL-3.0-only
+            GPL-1.0-only
+            GPL-2.0-only
+            GPL-3.0-only
+            LGPL-3.0-only
+            LGPL-2.0-only

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,55 @@
+name: release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build-and-attest:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: write
+      id-token: write
+      attestations: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile=false
+
+      - name: Build workspaces
+        run: |
+          pnpm -w -r build
+          pnpm --filter @speckit/core run build
+          pnpm --filter @speckit/cli run build
+
+      - name: Package release artifacts
+        run: |
+          mkdir -p release
+          tar -czf release/speckit-artifacts.tar.gz packages
+
+      - name: Upload release artifact
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: release/speckit-artifacts.tar.gz
+          asset_name: speckit-artifacts.tar.gz
+          asset_content_type: application/gzip
+
+      - name: Generate build provenance attestation
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: release/speckit-artifacts.tar.gz

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -1,0 +1,47 @@
+name: sbom
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  release:
+    types: [published]
+
+jobs:
+  generate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        run: |
+          corepack enable
+          pnpm install --frozen-lockfile=false
+
+      - name: Generate CycloneDX SBOM
+        run: npx @cyclonedx/cyclonedx-node-npm --output-format JSON --output-file bom.json
+
+      - name: Upload SBOM artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cyclone-dx-sbom
+          path: bom.json
+
+      - name: Attach SBOM to release
+        if: github.event_name == 'release'
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: bom.json
+          asset_name: speckit-sbom.json
+          asset_content_type: application/json


### PR DESCRIPTION
## Summary
- add dependency review workflow that blocks high severity advisories and disallowed licenses
- configure CodeQL analysis for JavaScript/TypeScript projects on pushes, PRs, and a weekly schedule
- publish release artifacts with provenance attestations and generate a CycloneDX SBOM that is attached to releases

## Testing
- not run (workflow updates only)

------
https://chatgpt.com/codex/tasks/task_e_68d457b1c1e48324ae3337ebe4ff4c29