### PR TITLE
Ensure prompts bundle enforces dialect compatibility

### DIFF
--- a/.speckit/catalog/prompts/standard/bundle.yaml
+++ b/.speckit/catalog/prompts/standard/bundle.yaml
@@ -3,6 +3,9 @@ name: "Standard Coding Prompts"
 kind: prompts
 version: "0.1.0"
 requires_speckit: ">=0.1.0 <1"
+requires_dialect:
+  id: speckit.v1
+  range: ">=1.0.0 <2"
 description: "Consolidated prompts for codegen/review/refactor workflows."
 prompts:
   - id: codegen

--- a/packages/adapter-owasp-asvs-v4/README.md
+++ b/packages/adapter-owasp-asvs-v4/README.md
@@ -1,0 +1,33 @@
+# @speckit/adapter-owasp-asvs-v4
+
+This package converts OWASP ASVS v4 YAML exports into the stable `SpecModel`
+shape used by Speckit templates. It allows the generation pipeline to treat
+ASVS content the same way as native Speckit dialects, making it easy to swap
+between dialects without changing templates.
+
+## Status
+
+The adapter focuses on structural mapping:
+
+- **Versioning** – resolves `meta.version`, `metadata.version`, or root
+  `version` values to the model `version` field.
+- **Requirement IDs** – normalises section and control identifiers (e.g.
+  `V1.1.1`) into canonical `SpecModel.requirements[].id` values.
+- **Levels** – converts ASVS level flags (`L1`/`L2`/`L3`) to the model `level`
+  plus companion tags.
+- **References** – carries over ASVS references as `SpecModel` references,
+  tagging each requirement with its originating OWASP identifier.
+
+Further normalisation (such as richer metadata mapping) can be layered on in a
+future release without touching downstream templates.
+
+## Usage
+
+```ts
+import { loadToModel } from "@speckit/adapter-owasp-asvs-v4";
+
+const model = await loadToModel("path/to/spec.yaml");
+```
+
+The resulting `SpecModel` is suitable for consumption by the generator and any
+Nunjucks bundles that expect the standard model contract.


### PR DESCRIPTION
## Summary
- require the speckit.v1 dialect for the standard prompts bundle to align with adapter gating
- document the OWASP ASVS v4 adapter contract so future dialect swaps stay template-stable

## Testing
- pnpm --filter @speckit/adapter-owasp-asvs-v4 build
- pnpm --filter @speckit/adapter-speckit-v1 build

------
https://chatgpt.com/codex/tasks/task_e_68d457bfac208324a860f9dde7ffcf8d