### PR TITLE
chore: guard catalog and modes changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
-.speckit/catalog/**  @airnub
+.speckit/catalog/**                                   @airnub
+.speckit/catalog.lock                                 @airnub
+packages/speckit-cli/src/config/modes.ts              @airnub

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -56,6 +56,7 @@ Paste as **valid JSON** if you used an agent; otherwise skip. This helps reviewe
 - [ ] Tests were added/updated and linked to **Req-ID(s)** in comments or filenames
 - [ ] No secrets / credentials committed
 - [ ] I linked relevant ADRs (or proposed a new one in `docs/internal/adr/`)
+- [ ] ⬜ Changing default mode (requires mode-change label & MAJOR bump)
 
 ## Breaking changes?
 - [ ] No


### PR DESCRIPTION
## Summary
- expand CODEOWNERS coverage to catalog lockfile and default mode configuration
- flag default-mode changes in the PR template with the required label + release expectations

## Governance updates
- Branch protection: Settings → Branches → edit default-branch rule → enable **Require review from Code Owners** (ensures catalog + mode edits require @airnub review)
- Push ruleset: Settings → Rules → Add ruleset → Push → limit to repository default branch → Target file paths `.speckit/catalog/**`, `.speckit/catalog.lock`, `packages/speckit-cli/src/config/modes.ts` → require pull request + required status checks

## Testing
- not run (metadata-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d4626c9f108324b362797d244bf5f4