### PR TITLE
Add OPA mode guard policy

### DIFF
--- a/.github/workflows/opa-guard.yml
+++ b/.github/workflows/opa-guard.yml
@@ -1,0 +1,58 @@
+name: Mode Policy Gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+jobs:
+  opa-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Collect PR context
+        id: context
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map(label => label.name);
+            const files = await github.paginate(
+              github.rest.pulls.listFiles,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number,
+                per_page: 100
+              }
+            );
+            const data = {
+              labels,
+              files: files.map(file => ({
+                path: file.filename,
+                status: file.status,
+                previous_path: file.previous_filename || null
+              }))
+            };
+            fs.writeFileSync('pr-context.json', JSON.stringify(data, null, 2));
+            core.setOutput('json-path', 'pr-context.json');
+
+      - name: Install Conftest
+        run: |
+          set -euo pipefail
+          version="0.45.0"
+          curl -sSL -o conftest.tar.gz "https://github.com/open-policy-agent/conftest/releases/download/v${version}/conftest_${version}_Linux_x86_64.tar.gz"
+          tar -xzf conftest.tar.gz
+          sudo install -m 0755 conftest /usr/local/bin/conftest
+          rm -f conftest.tar.gz
+          conftest --version
+
+      - name: Evaluate policies
+        run: conftest test pr-context.json --policy policy

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@
 - **Single source of truth** is `.speckit/spec.yaml`. Run `speckit gen --write` to refresh generated docs in `docs/specs/`, then commit the results.
 - **Verification** is enforced by the `speckit-verify` workflow, which fails the build if generated docs drift from the spec.
 
+## Mode Policy Gate
+
+PRs that change `packages/speckit-cli/src/config/modes.ts` or remove files inside the classic templates (`blank`, `next-supabase`, `speckit-template`) must carry the `mode-change` label. The OPA/Conftest gate fails any pull request that makes those adjustments without the label applied.
+
 ## Dialect & Adapters
 
 SpecKit now routes every generation through a normalized **SpecModel**. The repository declares its input dialect in `.speckit/spec.yaml` (`dialect.id` + `dialect.version`), and the CLI picks the matching adapter at runtime. Today the catalog ships with two adapters:

--- a/policy/modes.rego
+++ b/policy/modes.rego
@@ -1,0 +1,54 @@
+package main
+
+mode_change_label := "mode-change"
+classic_template_ids := {"blank", "next-supabase", "speckit-template"}
+
+has_mode_change_label {
+  labels := input.labels
+  labels != null
+  label := labels[_]
+  lower(label) == mode_change_label
+}
+
+is_modes_path(path) {
+  path == "packages/speckit-cli/src/config/modes.ts"
+}
+
+modes_file_changed(file) {
+  is_modes_path(file.path)
+}
+
+modes_file_changed(file) {
+  prev := file.previous_path
+  prev != null
+  is_modes_path(prev)
+}
+
+matches_classic_template(path, id) {
+  pattern := sprintf("(^|/)templates/%s($|/|\\.)", [id])
+  re_match(pattern, path)
+}
+
+classic_template_label(path) = id {
+  id := classic_template_ids[_]
+  matches_classic_template(path, id)
+}
+
+deny[msg] {
+  files := input.files
+  files != null
+  file := files[_]
+  modes_file_changed(file)
+  not has_mode_change_label
+  msg := "mode-change label is required when changing packages/speckit-cli/src/config/modes.ts"
+}
+
+deny[msg] {
+  files := input.files
+  files != null
+  file := files[_]
+  file.status == "removed"
+  template_id := classic_template_label(file.path)
+  not has_mode_change_label
+  msg := sprintf("mode-change label is required when removing files from classic template '%s': %s", [template_id, file.path])
+}


### PR DESCRIPTION
## Summary
- add a Rego policy that blocks mode config edits or classic template removals unless the `mode-change` label is present
- add an `opa-guard` GitHub Action that assembles PR metadata and runs Conftest against the repository policies
- document the new mode policy gate expectations in the README

## Testing
- ./conftest test pr-context.json --policy policy

------
https://chatgpt.com/codex/tasks/task_e_68d462765e7c83249ae46b415e3a5546