### PR TITLE
feat: record generation mode and add doctor

### DIFF
--- a/.speckit/spec.yaml
+++ b/.speckit/spec.yaml
@@ -1,6 +1,8 @@
 dialect:
   id: speckit.v1
   version: 1.0.0
+engine:
+  mode: classic
 spec:
   meta:
     id: speckit

--- a/docs/specs/changelog-v1.0.0.md
+++ b/docs/specs/changelog-v1.0.0.md
@@ -9,6 +9,7 @@ speckit_provenance:
   tool: speckit
   tool_version: 0.1.0
   tool_commit: 59a61d9
+  mode: classic
   dialect:
     id: speckit.v1
     version: 1.0.0

--- a/docs/specs/coding-agent-brief-v1.0.0.md
+++ b/docs/specs/coding-agent-brief-v1.0.0.md
@@ -10,6 +10,7 @@ speckit_provenance:
   tool: speckit
   tool_version: 0.1.0
   tool_commit: 59a61d9
+  mode: classic
   dialect:
     id: speckit.v1
     version: 1.0.0

--- a/docs/specs/orchestration-plan-v1.0.0.md
+++ b/docs/specs/orchestration-plan-v1.0.0.md
@@ -12,6 +12,7 @@ speckit_provenance:
   tool: speckit
   tool_version: 0.1.0
   tool_commit: 59a61d9
+  mode: classic
   dialect:
     id: speckit.v1
     version: 1.0.0

--- a/docs/specs/speckit-spec-v1.0.0.md
+++ b/docs/specs/speckit-spec-v1.0.0.md
@@ -12,6 +12,7 @@ speckit_provenance:
   tool: speckit
   tool_version: 0.1.0
   tool_commit: 59a61d9
+  mode: classic
   dialect:
     id: speckit.v1
     version: 1.0.0

--- a/packages/speckit-cli/src/cli.ts
+++ b/packages/speckit-cli/src/cli.ts
@@ -8,6 +8,7 @@ import { TemplateListCommand, TemplateUseCommand } from "./commands/template.js"
 import { InitFromTemplateCommand } from "./commands/init.js";
 import { GenerateDocsCommand } from "./commands/gen.js";
 import { AuditCommand } from "./commands/audit.js";
+import { DoctorCommand } from "./commands/doctor.js";
 
 cfonts.say("speckit", { font: "block" });
 console.log(
@@ -29,5 +30,6 @@ cli.register(TemplateUseCommand);
 cli.register(InitFromTemplateCommand);
 cli.register(GenerateDocsCommand);
 cli.register(AuditCommand);
+cli.register(DoctorCommand);
 
 cli.runExit(args, Cli.defaultContext);

--- a/packages/speckit-cli/src/commands/doctor.ts
+++ b/packages/speckit-cli/src/commands/doctor.ts
@@ -1,0 +1,85 @@
+import { Command } from "clipanion";
+import path from "node:path";
+import fs from "fs-extra";
+import { loadTemplates } from "@speckit/core";
+import { loadSpecModel } from "../services/spec.js";
+import {
+  GENERATION_MODES,
+  resolveDefaultGenerationMode,
+  templateModes,
+} from "../services/mode.js";
+
+export class DoctorCommand extends Command {
+  static paths = [["doctor"]];
+
+  async execute() {
+    try {
+      const repoRoot = process.cwd();
+      const { data } = await loadSpecModel(repoRoot);
+      const defaultMode = resolveDefaultGenerationMode(data);
+      const templates = await loadTemplates({ repoRoot });
+
+      const grouped = new Map<string, string[]>();
+      for (const mode of GENERATION_MODES) {
+        grouped.set(mode, []);
+      }
+      for (const entry of templates) {
+        const modes = templateModes(entry);
+        for (const mode of modes) {
+          const bucket = grouped.get(mode) ?? [];
+          bucket.push(entry.name);
+          grouped.set(mode, bucket);
+        }
+      }
+      for (const bucket of grouped.values()) {
+        bucket.sort((a, b) => a.localeCompare(b));
+      }
+
+      const policyResults: { label: string; ok: boolean; detail?: string }[] = [];
+      const catalogGatePath = path.join(repoRoot, ".github", "workflows", "catalog-protect.yml");
+      const hasCatalogGate = await fs.pathExists(catalogGatePath);
+      policyResults.push({ label: "Catalog gate workflow present", ok: hasCatalogGate });
+      if (hasCatalogGate) {
+        const content = await fs.readFile(catalogGatePath, "utf8");
+        const enforcesLabel = content.includes("catalog:allowed");
+        policyResults.push({
+          label: "Catalog gate requires 'catalog:allowed' label",
+          ok: enforcesLabel,
+          detail: enforcesLabel ? undefined : "Add label check to catalog-protect.yml",
+        });
+      } else {
+        policyResults.push({
+          label: "Catalog gate requires 'catalog:allowed' label",
+          ok: false,
+          detail: "Missing .github/workflows/catalog-protect.yml",
+        });
+      }
+
+      this.context.stdout.write("Speckit Doctor\n===============\n\n");
+      this.context.stdout.write(`Default generation mode: ${defaultMode}\n\n`);
+      this.context.stdout.write("Templates by mode:\n");
+      for (const mode of GENERATION_MODES) {
+        const templatesForMode = grouped.get(mode) ?? [];
+        const list = templatesForMode.length ? templatesForMode.join(", ") : "(none)";
+        this.context.stdout.write(`  - ${mode}: ${list}\n`);
+      }
+
+      this.context.stdout.write("\nPolicy checks:\n");
+      let hasFailures = false;
+      for (const result of policyResults) {
+        const symbol = result.ok ? "✔" : "✖";
+        if (!result.ok) {
+          hasFailures = true;
+        }
+        const detail = result.detail ? ` — ${result.detail}` : "";
+        this.context.stdout.write(`  ${symbol} ${result.label}${detail}\n`);
+      }
+
+      return hasFailures ? 1 : 0;
+    } catch (error: any) {
+      const message = error?.message ?? String(error);
+      this.context.stderr.write(`speckit doctor failed: ${message}\n`);
+      return 1;
+    }
+  }
+}

--- a/packages/speckit-cli/src/services/manifest.ts
+++ b/packages/speckit-cli/src/services/manifest.ts
@@ -3,8 +3,11 @@ import fs from "fs-extra";
 import { z } from "zod";
 import type { SpeckitVersionInfo } from "./version.js";
 
+const GenerationModeSchema = z.enum(["classic", "secure"]);
+
 const ManifestRunSchema = z.object({
   at: z.string(),
+  mode: GenerationModeSchema.default("classic"),
   dialect: z
     .object({ id: z.string(), version: z.string() })
     .optional(),
@@ -69,6 +72,7 @@ export async function appendManifestRun(
   manifest.speckit = { version: info.version, commit: info.commit };
   const enriched: ManifestRun = {
     ...run,
+    mode: run.mode ?? "classic",
     dialect: run.dialect ?? { id: "unknown", version: "unknown" },
     synced_with: run.synced_with ?? { version: info.version, commit: info.commit },
   };

--- a/packages/speckit-cli/src/services/mode.ts
+++ b/packages/speckit-cli/src/services/mode.ts
@@ -1,0 +1,47 @@
+import type { GenerationMode, TemplateEntry } from "@speckit/core";
+
+export const DEFAULT_GENERATION_MODE: GenerationMode = "classic";
+export const GENERATION_MODES: GenerationMode[] = ["classic", "secure"];
+
+const MODE_SET = new Set<GenerationMode>(GENERATION_MODES);
+
+export function parseGenerationMode(value: unknown): GenerationMode | null {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return null;
+  const candidate = normalized as GenerationMode;
+  return MODE_SET.has(candidate) ? candidate : null;
+}
+
+export function resolveDefaultGenerationMode(specData: any): GenerationMode {
+  const candidates: unknown[] = [];
+  if (specData) {
+    const engineMode = specData?.engine?.mode ?? specData?.generator?.mode;
+    const legacy = specData?.speckit?.mode ?? specData?.mode;
+    if (engineMode !== undefined) candidates.push(engineMode);
+    if (legacy !== undefined) candidates.push(legacy);
+  }
+  candidates.push(process.env.SPECKIT_DEFAULT_MODE);
+  candidates.push(process.env.SPECKIT_MODE);
+
+  for (const candidate of candidates) {
+    const parsed = parseGenerationMode(candidate);
+    if (parsed) return parsed;
+  }
+  return DEFAULT_GENERATION_MODE;
+}
+
+export function templateModes(template: TemplateEntry): GenerationMode[] {
+  const list = template?.modes ?? [];
+  const seen = new Set<GenerationMode>();
+  for (const entry of list) {
+    const parsed = parseGenerationMode(entry);
+    if (parsed) {
+      seen.add(parsed);
+    }
+  }
+  if (seen.size > 0) {
+    return Array.from(seen);
+  }
+  return [DEFAULT_GENERATION_MODE];
+}

--- a/packages/speckit-gen-tests/src/__snapshots__/generator.snap.test.ts.snap
+++ b/packages/speckit-gen-tests/src/__snapshots__/generator.snap.test.ts.snap
@@ -8,6 +8,7 @@ speckit_provenance:
   tool: speckit
   tool_version: 0.1.0
   tool_commit: abc1234
+  mode: classic
   dialect:
     id: speckit.v1
     version: 1.1.0

--- a/packages/speckit-gen-tests/src/generator.snap.test.ts
+++ b/packages/speckit-gen-tests/src/generator.snap.test.ts
@@ -49,7 +49,11 @@ const bundle: BundleDefinition = {
 };
 
 vi.mock("../../speckit-cli/src/services/spec.js", () => ({
-  loadSpecModel: vi.fn(async () => ({ model: mockModel, dialect: mockDialect, data: {} })),
+  loadSpecModel: vi.fn(async () => ({
+    model: mockModel,
+    dialect: mockDialect,
+    data: { engine: { mode: "classic" } },
+  })),
   hashSpecYaml: vi.fn(async () => "sha256:mock-spec-digest"),
 }));
 


### PR DESCRIPTION
## Summary
- include generation mode in spec metadata, front-matter provenance, and generation ledger entries
- add shared helpers and CLI plumbing so mode-aware generation, manifest validation, and template metadata work together
- introduce `speckit doctor` for summarising default mode, templates-by-mode, and catalog gate checks

## Testing
- pnpm -r test

------
https://chatgpt.com/codex/tasks/task_e_68d462816ea083248d965e18bde30e90