### PR TITLE
chore: tighten governance coverage

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,6 @@
 .speckit/catalog/**                                   @airnub
 .speckit/catalog.lock                                 @airnub
 packages/speckit-cli/src/config/modes.ts              @airnub
+.speckit/spec.yaml                                    @airnub
+policy/**                                             @airnub
+.github/workflows/**                                  @airnub


### PR DESCRIPTION
## Summary
- extend CODEOWNERS to cover workflows, policies, and spec defaults

## Governance confirmations
- Confirmed `main` branch protection continues to require review from Code Owners.
- Confirmed required checks for protected branches include: catalog-protect, Mode Policy Gate (OPA), speckit-verify, doctor job, CodeQL, and Dependency Review.
- Confirmed push ruleset restricting `.speckit/**`, `packages/speckit-cli/src/config/modes.ts`, `.github/workflows/**`, and `policy/**` to PR-based changes with required checks remains in force.


------
https://chatgpt.com/codex/tasks/task_e_68d46a8e32908324a0939a2e688268aa