### PR TITLE
ci: run speckit doctor with gating

### DIFF
--- a/.github/workflows/speckit-verify.yml
+++ b/.github/workflows/speckit-verify.yml
@@ -23,3 +23,108 @@ jobs:
         run: node packages/speckit-cli/dist/cli.js audit
       - name: Fail if generated docs drift
         run: git diff --exit-code || (echo "Generated docs drift detected. Run 'speckit gen --write' and commit." && exit 1)
+      - name: Run Speckit Doctor
+        id: doctor
+        shell: bash
+        run: node packages/speckit-cli/dist/cli.js doctor --json > doctor-report.json
+        continue-on-error: true
+      - name: Upload doctor report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: doctor-report
+          path: doctor-report.json
+      - name: Comment doctor summary
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const path = 'doctor-report.json';
+            if (!fs.existsSync(path)) {
+              core.warning('doctor-report.json missing; skipping doctor comment.');
+              return;
+            }
+            const report = JSON.parse(fs.readFileSync(path, 'utf8'));
+            const policies = Array.isArray(report.policies) ? report.policies : [];
+            const templates = report.templatesByMode ?? {};
+            const lines = ['| Check | Status | Detail |', '| --- | --- | --- |'];
+            for (const policy of policies) {
+              lines.push(`| ${policy.label} | ${policy.ok ? '✅' : '❌'} | ${policy.detail ?? ''} |`);
+            }
+            const marker = '<!-- speckit-doctor-report -->';
+            const body = [
+              marker,
+              '## Speckit Doctor Report',
+              '',
+              `**Default mode:** ${report.defaultMode ?? 'unknown'}`,
+              '',
+              '### Templates',
+              '',
+              '```json',
+              JSON.stringify(templates, null, 2),
+              '```',
+              '',
+              '### Policy Checks',
+              '',
+              lines.join('\n'),
+              marker,
+            ].join('\n');
+            const { owner, repo } = context.repo;
+            const issue_number = context.issue.number;
+            const { data: comments } = await github.rest.issues.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.find((comment) => comment.body && comment.body.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+            } else {
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+      - name: Enforce doctor policies
+        if: always()
+        env:
+          DOCTOR_OUTCOME: ${{ steps.doctor.outcome }}
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const failures = [];
+          const outcome = process.env.DOCTOR_OUTCOME;
+          if (!fs.existsSync('doctor-report.json')) {
+            failures.push('doctor-report.json was not produced.');
+          }
+          let report = null;
+          if (fs.existsSync('doctor-report.json')) {
+            try {
+              report = JSON.parse(fs.readFileSync('doctor-report.json', 'utf8'));
+            } catch (error) {
+              failures.push(`Failed to parse doctor-report.json: ${error.message}`);
+            }
+          }
+          if (report) {
+            const defaultMode = typeof report.defaultMode === 'string' ? report.defaultMode.toLowerCase() : '';
+            if (defaultMode !== 'classic') {
+              failures.push(`Default mode must be 'classic' but was '${report.defaultMode ?? 'unknown'}'.`);
+            }
+            const templatesByMode = report.templatesByMode ?? {};
+            const classicTemplates = Array.isArray(templatesByMode.classic) ? templatesByMode.classic : [];
+            if (classicTemplates.length === 0) {
+              failures.push('No templates registered for classic mode.');
+            }
+            const policies = Array.isArray(report.policies) ? report.policies : [];
+            const requirePolicyOk = (label, message) => {
+              const entry = policies.find((policy) => policy.label === label);
+              if (!entry || !entry.ok) {
+                const detail = entry && entry.detail ? ` (${entry.detail})` : '';
+                failures.push(`${message}${detail}`);
+              }
+            };
+            requirePolicyOk('Catalog gate workflow present', 'Catalog gate workflow is missing.');
+            requirePolicyOk("Catalog gate requires 'catalog:allowed' label", "Catalog guard must require the 'catalog:allowed' label.");
+          }
+          if (outcome && outcome !== 'success') {
+            failures.push('speckit doctor command reported a failure.');
+          }
+          if (failures.length > 0) {
+            console.error('Doctor guard failures:\n - ' + failures.join('\n - '));
+            process.exit(1);
+          }
+          NODE

--- a/packages/speckit-cli/src/cli.ts
+++ b/packages/speckit-cli/src/cli.ts
@@ -10,15 +10,19 @@ import { GenerateDocsCommand } from "./commands/gen.js";
 import { AuditCommand } from "./commands/audit.js";
 import { DoctorCommand } from "./commands/doctor.js";
 
-cfonts.say("speckit", { font: "block" });
-console.log(
-  boxen(
-    "speckit v0.0.1 (alias: spec): `speckit template list` · `speckit init --template next-supabase` · `speckit init --template speckit-template`",
-    { padding: 1, borderStyle: "round" },
-  ),
-);
-
 const [, , ...args] = process.argv;
+
+const suppressBanner = args.includes("--json");
+
+if (!suppressBanner) {
+  cfonts.say("speckit", { font: "block" });
+  console.log(
+    boxen(
+      "speckit v0.0.1 (alias: spec): `speckit template list` · `speckit init --template next-supabase` · `speckit init --template speckit-template`",
+      { padding: 1, borderStyle: "round" },
+    ),
+  );
+}
 const cli = new Cli({ binaryLabel: "speckit", binaryName: "speckit", binaryVersion: "0.0.1" });
 
 cli.register(Builtins.HelpCommand);


### PR DESCRIPTION
## Summary
- extend the speckit-verify workflow to run `speckit doctor --json`, upload the report, comment on PRs, and enforce doctor guard failures
- teach the doctor command to expose JSON output along with explicit classic/default-mode and catalog policy checks
- suppress the CLI banner when JSON output is requested so the report stays machine-readable

## Testing
- pnpm --filter @speckit/cli run build

------
https://chatgpt.com/codex/tasks/task_e_68d46a5cc7888324bbbca73d45921fa0