### PR TITLE
feat: add edu-us compliance bundles and CLI tooling

### DIFF
--- a/.speckit/catalog/specs/compliance/edu-us/cipa/cipa-filtering-and-monitoring.md
+++ b/.speckit/catalog/specs/compliance/edu-us/cipa/cipa-filtering-and-monitoring.md
@@ -1,0 +1,26 @@
+# CIPA Filtering and Monitoring Guardrails
+
+The Children's Internet Protection Act (CIPA) sets conditions for schools and libraries that receive E-Rate discounts. Use this outline to confirm your security program documents the required filtering and monitoring practices.
+
+## Technology protection measures
+
+- Maintain an inventory of web filtering solutions that block access to obscene or harmful visual content as defined in 47 U.S.C. §254(h).
+- Describe how the filters are applied across managed devices, guest networks, and any cloud applications students access.
+- Document the exception approval process when instructional staff need temporary access to blocked resources.
+
+## Monitoring and safety policies
+
+- Publish an Internet safety policy covering monitoring practices, social media use, and student education on appropriate online behavior (47 CFR §54.520).
+- Retain meeting minutes or board approvals that show the policy was adopted after reasonable public notice and hearing.
+- Record how monitoring alerts are triaged, escalated, and closed to demonstrate oversight.
+
+## E-Rate eligibility attestations
+
+- Keep annual certifications that the district enforces its filtering and monitoring policies as a condition of E-Rate funding.
+- Track any outages or filter bypass events and the remediation steps taken.
+- Ensure procurement packages reference CIPA requirements when acquiring new filtering or monitoring tools.
+
+## References
+
+- Federal Communications Commission: CIPA Guidance (<https://www.fcc.gov/consumers/guides/childrens-internet-protection-act>)
+- Universal Service Administrative Company (USAC): CIPA Compliance (<https://www.usac.org/sl/applicants/step02/cipa-requirements/>)

--- a/.speckit/catalog/specs/compliance/edu-us/coppa/coppa-consent-and-dataflow.md
+++ b/.speckit/catalog/specs/compliance/edu-us/coppa/coppa-consent-and-dataflow.md
@@ -1,0 +1,26 @@
+# COPPA Consent and Data Flow Checklist
+
+The Children's Online Privacy Protection Act (COPPA) requires verifiable parental consent before collecting personal information from children under 13. This checklist highlights the operational guardrails education products must document.
+
+## Verifiable parental consent
+
+- Capture the consent mechanism used (e.g., signed form, ID verification, payment credential) and store timestamps for audit readiness.
+- Provide a workflow for revoking consent and removing associated child data.
+- Maintain consent evidence for as long as the child's account is active plus the retention period documented below.
+
+## Direct notices and privacy disclosures
+
+- Publish a child-directed privacy notice explaining the categories of data collected, operators involved, and how parents can contact the service (16 CFR §312.4).
+- Send direct notice to parents before collecting information from a child, referencing the specific activities that require data.
+- Track which disclosures have been delivered and confirm that records exist for each child's parent or guardian.
+
+## Data retention and deletion limits
+
+- Document the maximum retention period for child data and ensure systems automatically purge records when no longer needed (16 CFR §312.10).
+- Verify backups, analytics exports, and support systems follow the same retention clock.
+- Provide a workflow to respond to parental deletion requests within a reasonable timeframe.
+
+## References
+
+- Federal Trade Commission: Children's Online Privacy Protection Rule (<https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa>)
+- COPPA FAQs for EdTech Operators (<https://www.ftc.gov/business-guidance/privacy-security/childrens-privacy>)

--- a/.speckit/catalog/specs/compliance/edu-us/ferpa/ferpa-privacy-checklist.md
+++ b/.speckit/catalog/specs/compliance/edu-us/ferpa/ferpa-privacy-checklist.md
@@ -1,0 +1,26 @@
+# FERPA Privacy Checklist
+
+The Family Educational Rights and Privacy Act (FERPA) protects student education records and governs how schools disclose, access, and safeguard student information. Use this checklist to confirm the core privacy controls are documented when you assemble a U.S. education compliance package.
+
+## Disclosure controls
+
+- Maintain a written policy that describes how the district or operator authorizes disclosures without consent under 34 CFR §99.31.
+- Log all disclosures internally so parents and eligible students can review who accessed their records.
+- Train staff on minimum necessary disclosures and annual FERPA awareness expectations.
+
+## Directory information boundaries
+
+- Publish the fields that are considered "directory information" and explain how families can opt out (34 CFR §99.37).
+- Document the review cadence for directory information designations and the communication process for opt-out deadlines.
+- Ensure any student directory exports are scoped to the published fields and remove suppressed entries.
+
+## Access and amendment rights
+
+- Provide a documented request process that lets parents or eligible students inspect and review education records within 45 days.
+- Describe how amendment requests are handled, including hearing procedures when the school refuses to amend records (34 CFR §§99.20–99.22).
+- Track fulfillment timelines to prove the district meets FERPA's response windows.
+
+## References
+
+- U.S. Department of Education — Student Privacy Policy Office: FERPA Guidance (<https://studentprivacy.ed.gov/ferpa>)
+- Electronic Code of Federal Regulations, Title 34 Part 99 (<https://www.ecfr.gov/current/title-34/subtitle-A/part-99>)

--- a/.speckit/catalog/specs/compliance/edu-us/ppra/ppra-survey-controls.md
+++ b/.speckit/catalog/specs/compliance/edu-us/ppra/ppra-survey-controls.md
@@ -1,0 +1,26 @@
+# PPRA Survey Controls and Parental Rights
+
+The Protection of Pupil Rights Amendment (PPRA) limits how schools conduct surveys or collect information on sensitive topics. Use this checklist to show how your program protects student privacy and honors parental rights.
+
+## Sensitive survey approvals
+
+- Catalog all surveys that ask about political affiliations, mental health, sexual behavior, religious practices, or family income (20 U.S.C. §1232h).
+- Obtain school board approval and document the review criteria for each survey instrument.
+- Retain copies of survey instruments and evidence that parents were notified before administration.
+
+## Parental review and opt-out rights
+
+- Publish a policy describing how parents can inspect instructional materials, including third-party surveys or assessments.
+- Provide an opt-out form for non-emergency physical exams, personal surveys, or marketing-related data collection.
+- Track opt-out responses and ensure downstream systems suppress data collection for those students.
+
+## Data minimization and sharing safeguards
+
+- Limit survey data access to authorized staff and aggregate results when reporting to external stakeholders.
+- Document contracts or data-sharing agreements with third parties that analyze survey data.
+- Define retention and destruction timelines for survey responses, including backups and analytics exports.
+
+## References
+
+- U.S. Department of Education — PPRA Guidance (<https://studentprivacy.ed.gov/resources/protection-pupil-rights-amendment-ppra>)
+- 20 U.S.C. §1232h: Protection of Pupil Rights Amendment (<https://www.govinfo.gov/content/pkg/USCODE-2021-title20/html/USCODE-2021-title20-chap31-subchapIII-part4-sec1232h.htm>)

--- a/.speckit/catalog/specs/compliance/edu-us/state/ca-sopipa/ca-sopipa-operational-guardrails.md
+++ b/.speckit/catalog/specs/compliance/edu-us/state/ca-sopipa/ca-sopipa-operational-guardrails.md
@@ -1,0 +1,32 @@
+# California SOPIPA Operational Guardrails
+
+California's Student Online Personal Information Protection Act (SOPIPA, Cal. Bus. & Prof. Code §22584) restricts how operators of K-12 online services use student data. This overlay highlights controls to align your platform with state expectations.
+
+## Advertising and marketing restrictions
+
+- Prohibit behaviorally targeted advertising on K-12 students when using data acquired through the service.
+- Block third-party ad tracking scripts in student-facing contexts and log technical controls that enforce the prohibition.
+- Confirm marketing teams cannot build lookalike audiences using covered student information.
+
+## Profiling and secondary use
+
+- Document how the service prevents creating student profiles for purposes other than K-12 school purposes.
+- Limit analytics dashboards to educational performance insights and strip identifiers when creating aggregate reports.
+- Review integrations to ensure vendors cannot use student data for non-educational data mining.
+
+## Data sale and disclosure bans
+
+- Maintain contracts that forbid the sale or rental of student information to third parties.
+- Track any required disclosures (e.g., law enforcement) and document the legal basis for each release.
+- Verify that directory or marketing exports exclude SOPIPA-protected data.
+
+## Deletion on request
+
+- Provide a workflow for schools or districts to request deletion of student data and confirm completion.
+- Ensure deletion propagates to backups, logging, and support tooling.
+- Record turnaround times and responsible teams for each deletion ticket.
+
+## References
+
+- California Legislature: SOPIPA (Cal. Bus. & Prof. Code §22584) (<https://leginfo.legislature.ca.gov/faces/codes_displayText.xhtml?lawCode=BPC&division=8.&title=&part=&chapter=22.&article=6.5.>)
+- California Department of Justice — Student Data Privacy Guidance (<https://oag.ca.gov/edtech>)

--- a/.speckit/catalog/specs/compliance/edu-us/state/ny-edlaw-2d/ny-edlaw-2d-parent-rights.md
+++ b/.speckit/catalog/specs/compliance/edu-us/state/ny-edlaw-2d/ny-edlaw-2d-parent-rights.md
@@ -1,0 +1,32 @@
+# New York Education Law 2-d Overlay
+
+New York's Education Law 2-d and the Board of Regents Part 121 regulations require schools and vendors to adopt specific privacy measures. This overlay summarizes the artifacts districts expect during procurement and annual reviews.
+
+## Parent Bill of Rights
+
+- Publish the district's Parent Bill of Rights for Data Privacy and Security in a location that is easy for families to find.
+- Include the required statements on student data use, third-party contracts, encryption, breach response, and parental rights.
+- Provide a way to request translations or accessible formats.
+
+## Data privacy and security policy
+
+- Post the district-wide Data Privacy and Security Policy that aligns with the NIST Cybersecurity Framework.
+- Document how the policy is reviewed annually and approved by the board of education.
+- Share how vendors must comply with Part 121 and Education Law 2-d obligations.
+
+## Data Protection Officer (DPO)
+
+- Identify the appointed DPO and publish contact information for incident response and parental inquiries.
+- Maintain training records demonstrating the DPO and staff understand FERPA, NYSED guidance, and breach notification rules.
+- Provide escalation paths for third-party vendors to contact the DPO when incidents occur.
+
+## Third-party contracts and supplemental information
+
+- Post contracts with third-party contractors, including supplemental information that explains data elements shared, the contract term, and security controls (Education Law 2-d §2).
+- Track expiration dates and renewal checkpoints to confirm continued compliance.
+- Ensure each contract includes a signed data privacy and security plan.
+
+## References
+
+- New York State Education Department: Education Law §2-d Guidance (<https://www.nysed.gov/data-privacy-security/parents-bill-rights-data-privacy-and-security>)
+- New York State Senate: Education Law §2-d (<https://www.nysenate.gov/legislation/laws/EDN/2-D>)

--- a/README.md
+++ b/README.md
@@ -92,6 +92,20 @@ speckit doctor
 speckit verify
 ```
 
+### Secure mode: Education (US)
+
+When a team opts into the U.S. education guardrails you can generate a compliance plan and verify supporting evidence directly from the CLI. The bundle aligns with guidance from the [U.S. Department of Education Student Privacy Policy Office](https://studentprivacy.ed.gov/), the [Federal Trade Commission's COPPA program](https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa), and the [Federal Communications Commission's CIPA resources](https://www.fcc.gov/consumers/guides/childrens-internet-protection-act).
+
+```bash
+# build a plan that layers FERPA, COPPA, CIPA, and PPRA with state overlays
+speckit compliance plan --framework edu-us --overlays ca-sopipa,ny-2d --format markdown --output compliance/edu-us-plan.md
+
+# evaluate the current repo against the required artifacts and tagged requirements
+speckit compliance verify --framework edu-us --overlays ca-sopipa,ny-2d --fail-on missing
+```
+
+The planner maps spec requirements tagged with `ferpa:*`, `coppa:*`, `cipa:*`, `ppra:*`, and state overlays such as `ca:sopipa:*` or `ny:2-d:*`. Verification reports summarize missing artifacts and call out matching Open Policy Agent checks located under `policy/opa/edu-us/*.rego` so PR reviewers can see exactly which FERPA/COPPA/CIPA/PPRA control is outstanding.
+
 ## Repo-local templates
 
 SpecKit automatically merges the built-in catalog with any directories that live under `.speckit/templates/**` in your current repo. Each directory becomes a selectable template (its name defaults to the relative path, e.g. `.speckit/templates/app/next` → `app/next`). Make sure the directory contains a manifest or at least one file; empty folders are ignored. The CLI (`speckit template list`, `speckit template use`, `speckit init --template …`; alias: swap `speckit` for `spec`) and the TUI picker (`N`) both surface these entries alongside the defaults. When you need something outside the catalog, pass a GitHub URL directly to `speckit template use …` or `speckit init --template …` (add `#branch` or `?ref=` if you need a branch other than the default—alias: `spec`).

--- a/packages/speckit-cli/src/cli.ts
+++ b/packages/speckit-cli/src/cli.ts
@@ -9,6 +9,7 @@ import { InitFromTemplateCommand } from "./commands/init.js";
 import { GenerateDocsCommand } from "./commands/gen.js";
 import { AuditCommand } from "./commands/audit.js";
 import { DoctorCommand } from "./commands/doctor.js";
+import { CompliancePlanCommand, ComplianceVerifyCommand } from "./commands/compliance.js";
 
 const [, , ...args] = process.argv;
 
@@ -35,5 +36,7 @@ cli.register(InitFromTemplateCommand);
 cli.register(GenerateDocsCommand);
 cli.register(AuditCommand);
 cli.register(DoctorCommand);
+cli.register(CompliancePlanCommand);
+cli.register(ComplianceVerifyCommand);
 
 cli.runExit(args, Cli.defaultContext);

--- a/packages/speckit-cli/src/commands/compliance.ts
+++ b/packages/speckit-cli/src/commands/compliance.ts
@@ -1,0 +1,142 @@
+import path from "node:path";
+import fs from "fs-extra";
+import { Command, Option } from "clipanion";
+import {
+  generateEduUsPlan,
+  verifyEduUsPlan,
+  renderEduUsPlanMarkdown,
+  renderEduUsReportMarkdown,
+} from "../services/compliance/index.js";
+
+const SUPPORTED_FRAMEWORKS = new Set(["edu-us"]);
+
+type OutputFormat = "markdown" | "json";
+type FailMode = "missing" | "none";
+
+export class CompliancePlanCommand extends Command {
+  static paths = [["compliance", "plan"]];
+
+  framework = Option.String("--framework", { required: true, description: "Compliance framework id" });
+  overlays = Option.Array("--overlays", { description: "Comma separated overlays", delimiter: "," });
+  format = Option.String("--format", { description: "Output format: markdown|json" });
+  output = Option.String("--output", { description: "Write plan to file" });
+
+  async execute(): Promise<number> {
+    try {
+      const framework = this.framework.trim().toLowerCase();
+      if (!SUPPORTED_FRAMEWORKS.has(framework)) {
+        this.context.stderr.write(`Unknown compliance framework '${this.framework}'.\n`);
+        return 1;
+      }
+      const overlays = normaliseOverlays(this.overlays);
+      const plan = await generateEduUsPlan({ repoRoot: process.cwd(), overlays });
+      const format = parseFormat(this.format);
+      const content = format === "json"
+        ? JSON.stringify(plan, null, 2)
+        : renderEduUsPlanMarkdown(plan);
+      await emitOutput(content, this.output, this.context.stdout);
+      if (this.output) {
+        this.context.stdout.write(
+          `Plan saved to ${path.relative(process.cwd(), path.resolve(this.output))}\n`
+        );
+      }
+      return 0;
+    } catch (error: any) {
+      const message = error?.message ?? String(error);
+      this.context.stderr.write(`speckit compliance plan failed: ${message}\n`);
+      return 1;
+    }
+  }
+}
+
+export class ComplianceVerifyCommand extends Command {
+  static paths = [["compliance", "verify"]];
+
+  framework = Option.String("--framework", { required: true, description: "Compliance framework id" });
+  overlays = Option.Array("--overlays", { description: "Comma separated overlays", delimiter: "," });
+  format = Option.String("--format", { description: "Output format: markdown|json" });
+  output = Option.String("--output", { description: "Write report to file" });
+  failOn = Option.String("--fail-on", { description: "Failure mode: missing|none" });
+
+  async execute(): Promise<number> {
+    try {
+      const framework = this.framework.trim().toLowerCase();
+      if (!SUPPORTED_FRAMEWORKS.has(framework)) {
+        this.context.stderr.write(`Unknown compliance framework '${this.framework}'.\n`);
+        return 1;
+      }
+      const overlays = normaliseOverlays(this.overlays);
+      const plan = await generateEduUsPlan({ repoRoot: process.cwd(), overlays });
+      const report = await verifyEduUsPlan(plan, { repoRoot: process.cwd() });
+      const format = parseFormat(this.format);
+      const content = format === "json"
+        ? JSON.stringify(report, null, 2)
+        : renderEduUsReportMarkdown(report);
+      await emitOutput(content, this.output, this.context.stdout);
+      if (this.output) {
+        this.context.stdout.write(
+          `Report saved to ${path.relative(process.cwd(), path.resolve(this.output))}\n`
+        );
+      }
+      const failMode = parseFailMode(this.failOn);
+      if (failMode === "missing" && report.summary.missing > 0) {
+        return 1;
+      }
+      return 0;
+    } catch (error: any) {
+      const message = error?.message ?? String(error);
+      this.context.stderr.write(`speckit compliance verify failed: ${message}\n`);
+      return 1;
+    }
+  }
+}
+
+function normaliseOverlays(values: string[] | undefined): string[] {
+  if (!values || values.length === 0) {
+    return [];
+  }
+  const resolved: string[] = [];
+  for (const value of values) {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) continue;
+    if (!resolved.includes(normalized)) {
+      resolved.push(normalized);
+    }
+  }
+  return resolved;
+}
+
+function parseFormat(value: string | undefined): OutputFormat {
+  if (!value) return "markdown";
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "markdown" || normalized === "md") {
+    return "markdown";
+  }
+  if (normalized === "json") {
+    return "json";
+  }
+  throw new Error(`Unsupported format '${value}'. Use markdown or json.`);
+}
+
+function parseFailMode(value: string | undefined): FailMode {
+  if (!value) return "missing";
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "missing") {
+    return "missing";
+  }
+  if (normalized === "none" || normalized === "never") {
+    return "none";
+  }
+  throw new Error(`Unsupported fail-on value '${value}'. Use missing or none.`);
+}
+
+async function emitOutput(content: string, outputPath: string | undefined, stdout: NodeJS.WriteStream): Promise<void> {
+  const finalContent = content.endsWith("\n") ? content : content + "\n";
+  if (outputPath) {
+    const absolute = path.resolve(outputPath);
+    await fs.ensureDir(path.dirname(absolute));
+    await fs.writeFile(absolute, finalContent, "utf8");
+  } else {
+    stdout.write(finalContent);
+  }
+}

--- a/packages/speckit-cli/src/services/compliance/edu-us.ts
+++ b/packages/speckit-cli/src/services/compliance/edu-us.ts
@@ -1,0 +1,960 @@
+import path from "node:path";
+import fs from "fs-extra";
+import type { Requirement } from "@speckit/core";
+import { loadSpecModel } from "../spec.js";
+
+export type ComplianceReference = { label: string; url?: string };
+export type ComplianceArtifact = { path: string; description?: string };
+export type ComplianceSeverity = "required" | "advisory";
+
+type ObligationGating = {
+  anyTags?: string[];
+  description?: string;
+};
+
+type ObligationDefinition = {
+  id: string;
+  title: string;
+  summary: string;
+  tags: string[];
+  references: ComplianceReference[];
+  expectedArtifacts?: ComplianceArtifact[];
+  severity: ComplianceSeverity;
+  opaPolicies?: string[];
+  gating?: ObligationGating;
+};
+
+type BundleDefinition = {
+  id: string;
+  title: string;
+  authority: string;
+  type: "federal" | "state";
+  overlays?: string[];
+  obligations: ObligationDefinition[];
+};
+
+type PlanMatch = {
+  id: string;
+  title: string;
+  tags: string[];
+};
+
+type PlanStatus = "covered" | "missing" | "not-applicable";
+
+type PlanEntry = {
+  id: string;
+  title: string;
+  bundleId: string;
+  bundleTitle: string;
+  authority: string;
+  summary: string;
+  tags: string[];
+  references: ComplianceReference[];
+  expectedArtifacts: ComplianceArtifact[];
+  severity: ComplianceSeverity;
+  status: PlanStatus;
+  matches: PlanMatch[];
+  opaPolicies: string[];
+  notApplicableReason?: string;
+};
+
+type PlanSource = {
+  id: string;
+  title: string;
+  authority: string;
+  type: "federal" | "state";
+};
+
+type PlanSummary = {
+  total: number;
+  covered: number;
+  missing: number;
+  notApplicable: number;
+};
+
+export type EduUsPlan = {
+  framework: "edu-us";
+  generatedAt: string;
+  overlaysApplied: string[];
+  summary: PlanSummary;
+  obligations: PlanEntry[];
+  sources: PlanSource[];
+  opaPolicies: { id: string; path: string; description: string }[];
+};
+
+type ReportStatus = "pass" | "missing" | "not-applicable";
+
+type ReportEntry = {
+  id: string;
+  title: string;
+  bundleId: string;
+  bundleTitle: string;
+  authority: string;
+  severity: ComplianceSeverity;
+  status: ReportStatus;
+  details: string[];
+  expectedArtifacts: ComplianceArtifact[];
+  missingArtifacts: ComplianceArtifact[];
+  matches: PlanMatch[];
+  opaPolicies: string[];
+  notApplicableReason?: string;
+};
+
+export type EduUsReport = {
+  framework: "edu-us";
+  generatedAt: string;
+  overlaysApplied: string[];
+  summary: {
+    evaluated: number;
+    pass: number;
+    missing: number;
+    notApplicable: number;
+  };
+  obligations: ReportEntry[];
+  alerts: {
+    obligationId: string;
+    title: string;
+    bundleTitle: string;
+    policies: string[];
+  }[];
+};
+
+type GenerateOptions = {
+  repoRoot: string;
+  overlays: string[];
+};
+
+const OPA_POLICIES = [
+  {
+    id: "coppa",
+    path: "policy/opa/edu-us/coppa.rego",
+    description: "COPPA consent, notice, and retention gating for child-directed features.",
+  },
+  {
+    id: "cipa",
+    path: "policy/opa/edu-us/cipa.rego",
+    description: "CIPA filtering and monitoring expectations when claiming E-Rate discounts.",
+  },
+  {
+    id: "ny-2d",
+    path: "policy/opa/edu-us/ny-2d.rego",
+    description: "New York Education Law 2-d parental rights and policy publication guardrails.",
+  },
+] as const;
+
+const FEDERAL_BUNDLES: BundleDefinition[] = [
+  {
+    id: "ferpa",
+    title: "FERPA Student Privacy",
+    authority: "U.S. Department of Education — Student Privacy Policy Office",
+    type: "federal",
+    obligations: [
+      {
+        id: "ferpa-disclosure-controls",
+        title: "Control disclosures of education records",
+        summary:
+          "Maintain written policies for authorized disclosures, logging, and staff training aligned with FERPA.",
+        tags: ["ferpa:disclosure-controls"],
+        references: [
+          { label: "34 CFR §99.31 — FERPA Exceptions" },
+          { label: "FERPA Guidance", url: "https://studentprivacy.ed.gov/ferpa" },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/ferpa/disclosure-logging.md",
+            description: "Disclosure authorization and logging procedure",
+          },
+        ],
+        severity: "required",
+      },
+      {
+        id: "ferpa-directory-information",
+        title: "Publish directory information boundaries",
+        summary:
+          "Define and communicate directory information fields plus opt-out processes for families.",
+        tags: ["ferpa:directory-info"],
+        references: [
+          { label: "34 CFR §99.37 — Directory information" },
+          { label: "FERPA Guidance", url: "https://studentprivacy.ed.gov/ferpa" },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/ferpa/directory-information-policy.md",
+            description: "Directory information policy",
+          },
+        ],
+        severity: "required",
+      },
+      {
+        id: "ferpa-access-rights",
+        title: "Document access and amendment rights",
+        summary:
+          "Describe how parents and eligible students request, review, and amend education records within statutory timelines.",
+        tags: ["ferpa:access-rights"],
+        references: [
+          { label: "34 CFR §§99.10–99.22 — Access and amendment" },
+          { label: "FERPA Guidance", url: "https://studentprivacy.ed.gov/ferpa" },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/ferpa/access-request-procedure.md",
+            description: "Record access and amendment process",
+          },
+        ],
+        severity: "required",
+      },
+    ],
+  },
+  {
+    id: "coppa",
+    title: "COPPA Child Privacy",
+    authority: "Federal Trade Commission",
+    type: "federal",
+    obligations: [
+      {
+        id: "coppa-parental-consent",
+        title: "Capture verifiable parental consent",
+        summary:
+          "Ensure a verifiable parental consent workflow exists before activating child accounts under age 13.",
+        tags: ["coppa:parental-consent"],
+        references: [
+          { label: "16 CFR §312.5 — Verifiable parental consent" },
+          {
+            label: "FTC COPPA Rule",
+            url: "https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/coppa/parental-consent-procedure.md",
+            description: "COPPA parental consent procedure",
+          },
+        ],
+        severity: "required",
+        opaPolicies: [OPA_POLICIES[0].path],
+        gating: {
+          anyTags: ["coppa:under-13", "coppa:child-directed"],
+          description: "Not applicable: spec has no child-directed COPPA tags (coppa:under-13 or coppa:child-directed).",
+        },
+      },
+      {
+        id: "coppa-direct-notice",
+        title: "Deliver direct notice to parents",
+        summary:
+          "Provide parents with direct notice describing data collection, operators, and contact channels before using child data.",
+        tags: ["coppa:direct-notice"],
+        references: [
+          { label: "16 CFR §312.4 — Direct notice" },
+          {
+            label: "FTC COPPA FAQs",
+            url: "https://www.ftc.gov/business-guidance/privacy-security/childrens-privacy",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/coppa/direct-notice-template.md",
+            description: "Direct notice template",
+          },
+        ],
+        severity: "required",
+        opaPolicies: [OPA_POLICIES[0].path],
+        gating: {
+          anyTags: ["coppa:under-13", "coppa:child-directed"],
+          description: "Not applicable: spec has no child-directed COPPA tags (coppa:under-13 or coppa:child-directed).",
+        },
+      },
+      {
+        id: "coppa-retention-limits",
+        title: "Define child data retention limits",
+        summary:
+          "State how long child personal information is retained and ensure purge workflows cover all systems.",
+        tags: ["coppa:data-retention"],
+        references: [
+          { label: "16 CFR §312.10 — Data retention and deletion" },
+          {
+            label: "FTC COPPA Rule",
+            url: "https://www.ftc.gov/legal-library/browse/rules/childrens-online-privacy-protection-rule-coppa",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/coppa/data-retention-schedule.md",
+            description: "Child data retention schedule",
+          },
+        ],
+        severity: "required",
+        opaPolicies: [OPA_POLICIES[0].path],
+        gating: {
+          anyTags: ["coppa:under-13", "coppa:child-directed"],
+          description: "Not applicable: spec has no child-directed COPPA tags (coppa:under-13 or coppa:child-directed).",
+        },
+      },
+    ],
+  },
+  {
+    id: "cipa",
+    title: "CIPA Filtering & Monitoring",
+    authority: "Federal Communications Commission",
+    type: "federal",
+    obligations: [
+      {
+        id: "cipa-filtering-monitoring",
+        title: "Publish filtering and monitoring policy",
+        summary:
+          "Document the technology protection measures and monitoring practices required for E-Rate discounts.",
+        tags: ["cipa:filtering"],
+        references: [
+          { label: "47 U.S.C. §254(h) — CIPA" },
+          {
+            label: "FCC CIPA Guidance",
+            url: "https://www.fcc.gov/consumers/guides/childrens-internet-protection-act",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/cipa/filtering-monitoring-policy.md",
+            description: "Filtering and monitoring policy",
+          },
+        ],
+        severity: "required",
+        opaPolicies: [OPA_POLICIES[1].path],
+        gating: {
+          anyTags: ["cipa:e-rate"],
+          description: "Not applicable: spec does not declare CIPA E-Rate obligations (missing cipa:e-rate tag).",
+        },
+      },
+    ],
+  },
+  {
+    id: "ppra",
+    title: "PPRA Survey Controls",
+    authority: "U.S. Department of Education — Student Privacy Policy Office",
+    type: "federal",
+    obligations: [
+      {
+        id: "ppra-sensitive-surveys",
+        title: "Review sensitive surveys",
+        summary:
+          "Catalog sensitive surveys and capture approvals before administering them to students.",
+        tags: ["ppra:sensitive-surveys"],
+        references: [
+          { label: "20 U.S.C. §1232h — PPRA" },
+          {
+            label: "PPRA Guidance",
+            url: "https://studentprivacy.ed.gov/resources/protection-pupil-rights-amendment-ppra",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/ppra/sensitive-survey-approvals.md",
+            description: "Sensitive survey approval log",
+          },
+        ],
+        severity: "required",
+      },
+      {
+        id: "ppra-parental-rights",
+        title: "Publish parental review and opt-out process",
+        summary:
+          "Explain how parents review instructional materials and opt out of PPRA-covered activities.",
+        tags: ["ppra:parent-rights"],
+        references: [
+          { label: "20 U.S.C. §1232h — PPRA" },
+          {
+            label: "PPRA Guidance",
+            url: "https://studentprivacy.ed.gov/resources/protection-pupil-rights-amendment-ppra",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/ppra/parental-notification-opt-out.md",
+            description: "PPRA parental notice and opt-out form",
+          },
+        ],
+        severity: "required",
+      },
+    ],
+  },
+];
+
+const STATE_BUNDLES: BundleDefinition[] = [
+  {
+    id: "ca-sopipa",
+    title: "California SOPIPA",
+    authority: "California Legislature",
+    type: "state",
+    overlays: ["ca-sopipa"],
+    obligations: [
+      {
+        id: "ca-sopipa-no-ads",
+        title: "Block targeted advertising",
+        summary:
+          "Ensure student information is never used for targeted advertising or creating marketing audiences.",
+        tags: ["ca:sopipa:ads"],
+        references: [
+          { label: "Cal. Bus. & Prof. Code §22584" },
+          {
+            label: "California DOJ EdTech Guidance",
+            url: "https://oag.ca.gov/edtech",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/state/ca-sopipa/advertising-ban.md",
+            description: "Advertising prohibition statement",
+          },
+        ],
+        severity: "required",
+      },
+      {
+        id: "ca-sopipa-profiling",
+        title: "Prevent unauthorized profiling",
+        summary:
+          "Limit analytics and profiling to K-12 school purposes and document technical safeguards.",
+        tags: ["ca:sopipa:profiling"],
+        references: [
+          { label: "Cal. Bus. & Prof. Code §22584" },
+          {
+            label: "California DOJ EdTech Guidance",
+            url: "https://oag.ca.gov/edtech",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/state/ca-sopipa/profiling-restrictions.md",
+            description: "Profiling restriction controls",
+          },
+        ],
+        severity: "required",
+      },
+      {
+        id: "ca-sopipa-no-sale",
+        title: "Ban selling student information",
+        summary:
+          "Record contractual and technical controls that prohibit selling or renting student data.",
+        tags: ["ca:sopipa:sale"],
+        references: [
+          { label: "Cal. Bus. & Prof. Code §22584" },
+          {
+            label: "California DOJ EdTech Guidance",
+            url: "https://oag.ca.gov/edtech",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/state/ca-sopipa/data-sale-prohibition.md",
+            description: "Student data sale prohibition",
+          },
+        ],
+        severity: "required",
+      },
+      {
+        id: "ca-sopipa-deletion",
+        title: "Support district deletion requests",
+        summary:
+          "Demonstrate deletion workflows that remove student data upon district request across systems.",
+        tags: ["ca:sopipa:deletion"],
+        references: [
+          { label: "Cal. Bus. & Prof. Code §22584" },
+          {
+            label: "California DOJ EdTech Guidance",
+            url: "https://oag.ca.gov/edtech",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/state/ca-sopipa/deletion-requests.md",
+            description: "Deletion request playbook",
+          },
+        ],
+        severity: "required",
+      },
+    ],
+  },
+  {
+    id: "ny-2d",
+    title: "New York Education Law 2-d",
+    authority: "New York State Education Department",
+    type: "state",
+    overlays: ["ny-2d"],
+    obligations: [
+      {
+        id: "ny-2d-parent-bill-of-rights",
+        title: "Post Parent Bill of Rights",
+        summary:
+          "Publish and maintain the Parent Bill of Rights for Data Privacy and Security.",
+        tags: ["ny:2-d:parent-rights"],
+        references: [
+          { label: "Education Law §2-d" },
+          {
+            label: "NYSED Parent Bill of Rights",
+            url: "https://www.nysed.gov/data-privacy-security/parents-bill-rights-data-privacy-and-security",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/state/ny-2d/parent-bill-of-rights.md",
+            description: "Published Parent Bill of Rights",
+          },
+        ],
+        severity: "required",
+        opaPolicies: [OPA_POLICIES[2].path],
+      },
+      {
+        id: "ny-2d-privacy-policy",
+        title: "Publish Data Privacy & Security Policy",
+        summary:
+          "Provide the district-wide data privacy and security policy aligned to the NIST CSF.",
+        tags: ["ny:2-d:privacy-policy"],
+        references: [
+          { label: "Education Law §2-d" },
+          {
+            label: "Part 121 Regulations",
+            url: "https://www.nysed.gov/common/nysed/files/programs/data-privacy-security/part121-text.pdf",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/state/ny-2d/data-privacy-security-policy.md",
+            description: "Data Privacy and Security Policy",
+          },
+        ],
+        severity: "required",
+        opaPolicies: [OPA_POLICIES[2].path],
+      },
+      {
+        id: "ny-2d-dpo",
+        title: "Identify Data Protection Officer",
+        summary:
+          "List the appointed Data Protection Officer and provide contact and training evidence.",
+        tags: ["ny:2-d:dpo"],
+        references: [
+          { label: "Education Law §2-d" },
+          { label: "NYSED Guidance", url: "https://www.nysed.gov/data-privacy-security" },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/state/ny-2d/data-protection-officer.md",
+            description: "Data Protection Officer contact and responsibilities",
+          },
+        ],
+        severity: "required",
+      },
+      {
+        id: "ny-2d-contracts",
+        title: "Disclose third-party contracts",
+        summary:
+          "Publish third-party contracts and supplemental information required by Education Law 2-d.",
+        tags: ["ny:2-d:contracts"],
+        references: [
+          { label: "Education Law §2-d" },
+          {
+            label: "NYSED Contract Requirements",
+            url: "https://www.nysed.gov/data-privacy-security/education-law-2-d",
+          },
+        ],
+        expectedArtifacts: [
+          {
+            path: "docs/compliance/edu-us/state/ny-2d/third-party-contracts.md",
+            description: "Third-party contract disclosures",
+          },
+        ],
+        severity: "required",
+      },
+    ],
+  },
+];
+
+const ALL_BUNDLES = [...FEDERAL_BUNDLES, ...STATE_BUNDLES];
+
+export async function generateEduUsPlan(options: GenerateOptions): Promise<EduUsPlan> {
+  const overlays = new Set(options.overlays.map(value => value.trim().toLowerCase()).filter(Boolean));
+  const { model } = await loadSpecModel(options.repoRoot);
+  const requirements = Array.isArray(model.requirements) ? model.requirements : [];
+  const tagIndex = buildTagIndex(requirements);
+  const globalTags = collectAllTags(requirements);
+
+  const planEntries: PlanEntry[] = [];
+  const includedBundles: BundleDefinition[] = [];
+
+  for (const bundle of ALL_BUNDLES) {
+    if (bundle.type === "state") {
+      const requiredOverlay = bundle.overlays ?? [];
+      const hasOverlay = requiredOverlay.some(id => overlays.has(id));
+      if (!hasOverlay) {
+        continue;
+      }
+    }
+    includedBundles.push(bundle);
+
+    for (const obligation of bundle.obligations) {
+      const matches = matchRequirements(obligation.tags, tagIndex);
+      const gating = evaluateGating(obligation.gating, globalTags);
+
+      const status: PlanStatus = gating.applies
+        ? matches.length > 0
+          ? "covered"
+          : "missing"
+        : "not-applicable";
+
+      planEntries.push({
+        id: obligation.id,
+        title: obligation.title,
+        bundleId: bundle.id,
+        bundleTitle: bundle.title,
+        authority: bundle.authority,
+        summary: obligation.summary,
+        tags: [...obligation.tags],
+        references: [...obligation.references],
+        expectedArtifacts: [...(obligation.expectedArtifacts ?? [])],
+        severity: obligation.severity,
+        status,
+        matches,
+        opaPolicies: [...(obligation.opaPolicies ?? [])],
+        notApplicableReason: gating.reason,
+      });
+    }
+  }
+
+  const summary = buildPlanSummary(planEntries);
+  const overlaysApplied = Array.from(overlays).sort();
+  const sources: PlanSource[] = includedBundles.map(bundle => ({
+    id: bundle.id,
+    title: bundle.title,
+    authority: bundle.authority,
+    type: bundle.type,
+  }));
+
+  return {
+    framework: "edu-us",
+    generatedAt: new Date().toISOString(),
+    overlaysApplied,
+    summary,
+    obligations: planEntries,
+    sources,
+    opaPolicies: OPA_POLICIES.map(policy => ({ ...policy })),
+  };
+}
+
+export async function verifyEduUsPlan(plan: EduUsPlan, options: { repoRoot: string }): Promise<EduUsReport> {
+  const repoRoot = options.repoRoot;
+  const reportEntries: ReportEntry[] = [];
+
+  for (const obligation of plan.obligations) {
+    if (obligation.status === "not-applicable") {
+      const detail = obligation.notApplicableReason ?? "Not applicable";
+      reportEntries.push({
+        id: obligation.id,
+        title: obligation.title,
+        bundleId: obligation.bundleId,
+        bundleTitle: obligation.bundleTitle,
+        authority: obligation.authority,
+        severity: obligation.severity,
+        status: "not-applicable",
+        details: [detail],
+        expectedArtifacts: obligation.expectedArtifacts,
+        missingArtifacts: [],
+        matches: obligation.matches,
+        opaPolicies: obligation.opaPolicies,
+        notApplicableReason: obligation.notApplicableReason,
+      });
+      continue;
+    }
+
+    const artifactResults = await Promise.all(
+      obligation.expectedArtifacts.map(async artifact => {
+        const exists = await fs.pathExists(path.join(repoRoot, artifact.path));
+        return { artifact, exists };
+      })
+    );
+
+    const missingArtifacts = artifactResults.filter(result => !result.exists).map(result => result.artifact);
+    const allArtifactsPresent = missingArtifacts.length === 0;
+    const hasSpecCoverage = obligation.matches.length > 0;
+    const status: ReportStatus = allArtifactsPresent && hasSpecCoverage ? "pass" : "missing";
+
+    const details: string[] = [];
+    if (hasSpecCoverage) {
+      const specCoverage = obligation.matches
+        .map(match => "`" + match.id + "`")
+        .join(", ");
+      details.push("Spec coverage: " + specCoverage);
+    } else {
+      details.push("Spec coverage missing — add requirements tagged with " + obligation.tags.join(", "));
+    }
+
+    if (obligation.expectedArtifacts.length > 0) {
+      if (allArtifactsPresent) {
+        details.push("Required artifacts present.");
+      } else {
+        const missingList = missingArtifacts.map(artifact => "`" + artifact.path + "`").join(", ");
+        details.push("Missing artifacts: " + missingList);
+      }
+    }
+
+    reportEntries.push({
+      id: obligation.id,
+      title: obligation.title,
+      bundleId: obligation.bundleId,
+      bundleTitle: obligation.bundleTitle,
+      authority: obligation.authority,
+      severity: obligation.severity,
+      status,
+      details,
+      expectedArtifacts: obligation.expectedArtifacts,
+      missingArtifacts,
+      matches: obligation.matches,
+      opaPolicies: obligation.opaPolicies,
+    });
+  }
+
+  const summary = buildReportSummary(reportEntries);
+  const alerts = reportEntries
+    .filter(entry => entry.status === "missing" && entry.opaPolicies.length > 0)
+    .map(entry => ({
+      obligationId: entry.id,
+      title: entry.title,
+      bundleTitle: entry.bundleTitle,
+      policies: entry.opaPolicies,
+    }));
+
+  return {
+    framework: plan.framework,
+    generatedAt: new Date().toISOString(),
+    overlaysApplied: [...plan.overlaysApplied],
+    summary,
+    obligations: reportEntries,
+    alerts,
+  };
+}
+
+export function renderEduUsPlanMarkdown(plan: EduUsPlan): string {
+  const lines: string[] = [];
+  lines.push("# Education (US) Compliance Plan");
+  lines.push("");
+  lines.push("Generated: " + plan.generatedAt);
+  lines.push(
+    "Overlays: " + (plan.overlaysApplied.length ? plan.overlaysApplied.join(", ") : "none")
+  );
+  lines.push("");
+  lines.push(
+    "Summary: " +
+      plan.summary.covered +
+      " covered · " +
+      plan.summary.missing +
+      " missing · " +
+      plan.summary.notApplicable +
+      " not applicable"
+  );
+  lines.push("");
+  lines.push("| Obligation | Bundle | Status | Matches |");
+  lines.push("| --- | --- | --- | --- |");
+  for (const entry of plan.obligations) {
+    const matches = entry.matches.length
+      ? entry.matches.map(match => "`" + match.id + "`").join(", ")
+      : entry.status === "not-applicable"
+        ? "—"
+        : "_none_";
+    lines.push(
+      "| " +
+        entry.title +
+        " | " +
+        entry.bundleTitle +
+        " | " +
+        formatPlanStatus(entry.status) +
+        " | " +
+        matches +
+        " |"
+    );
+  }
+  lines.push("");
+  if (plan.sources.length) {
+    lines.push("## Sources");
+    for (const source of plan.sources) {
+      lines.push("- " + source.title + " (" + source.type + ") — " + source.authority);
+    }
+    lines.push("");
+  }
+  if (plan.opaPolicies.length) {
+    lines.push("## OPA Policies");
+    for (const policy of plan.opaPolicies) {
+      lines.push("- " + policy.id + ": " + policy.path + " — " + policy.description);
+    }
+  }
+  return lines.join("\n");
+}
+
+export function renderEduUsReportMarkdown(report: EduUsReport): string {
+  const lines: string[] = [];
+  lines.push("# Education (US) Compliance Report");
+  lines.push("");
+  lines.push("Generated: " + report.generatedAt);
+  lines.push(
+    "Overlays: " + (report.overlaysApplied.length ? report.overlaysApplied.join(", ") : "none")
+  );
+  lines.push("");
+  lines.push(
+    "Summary: " +
+      report.summary.pass +
+      " pass · " +
+      report.summary.missing +
+      " missing · " +
+      report.summary.notApplicable +
+      " not applicable"
+  );
+  lines.push("");
+  if (report.alerts.length) {
+    lines.push("## Policy Alerts");
+    for (const alert of report.alerts) {
+      lines.push(
+        "- " + alert.title + " (" + alert.bundleTitle + ") → policies: " + alert.policies.join(", ")
+      );
+    }
+    lines.push("");
+  }
+  lines.push("## Obligation Results");
+  for (const entry of report.obligations) {
+    lines.push("- " + formatReportStatus(entry.status) + " " + entry.title + " (" + entry.bundleTitle + ")");
+    for (const detail of entry.details) {
+      lines.push("  - " + detail);
+    }
+    if (entry.expectedArtifacts.length) {
+      const list = entry.expectedArtifacts.map(artifact => "`" + artifact.path + "`").join(", ");
+      lines.push("  - Expected artifacts: " + list);
+    }
+    if (entry.missingArtifacts.length) {
+      const missingList = entry.missingArtifacts.map(artifact => "`" + artifact.path + "`").join(", ");
+      lines.push("  - Missing: " + missingList);
+    }
+  }
+  return lines.join("\n");
+}
+
+function buildTagIndex(requirements: Requirement[]): Map<string, Requirement[]> {
+  const index = new Map<string, Requirement[]>();
+  for (const requirement of requirements) {
+    if (!Array.isArray(requirement.tags)) continue;
+    for (const tag of requirement.tags) {
+      const normalised = normaliseTag(tag);
+      if (!normalised) continue;
+      const list = index.get(normalised) ?? [];
+      list.push(requirement);
+      index.set(normalised, list);
+    }
+  }
+  return index;
+}
+
+function collectAllTags(requirements: Requirement[]): Set<string> {
+  const tags = new Set<string>();
+  for (const requirement of requirements) {
+    if (!Array.isArray(requirement.tags)) continue;
+    for (const tag of requirement.tags) {
+      const normalised = normaliseTag(tag);
+      if (normalised) {
+        tags.add(normalised);
+      }
+    }
+  }
+  return tags;
+}
+
+function matchRequirements(tags: string[], tagIndex: Map<string, Requirement[]>): PlanMatch[] {
+  const matches = new Map<string, PlanMatch>();
+  for (const tag of tags) {
+    const normalised = normaliseTag(tag);
+    if (!normalised) continue;
+    const requirements = tagIndex.get(normalised) ?? [];
+    for (const requirement of requirements) {
+      if (!matches.has(requirement.id)) {
+        matches.set(requirement.id, {
+          id: requirement.id,
+          title: requirement.title,
+          tags: Array.isArray(requirement.tags) ? requirement.tags : [],
+        });
+      }
+    }
+  }
+  return Array.from(matches.values()).sort((a, b) => a.id.localeCompare(b.id));
+}
+
+function evaluateGating(gating: ObligationGating | undefined, globalTags: Set<string>): {
+  applies: boolean;
+  reason?: string;
+} {
+  if (!gating) {
+    return { applies: true };
+  }
+  if (gating.anyTags && gating.anyTags.length > 0) {
+    const hasTag = gating.anyTags.some(tag => globalTags.has(normaliseTag(tag)));
+    if (!hasTag) {
+      return { applies: false, reason: gating.description };
+    }
+  }
+  return { applies: true };
+}
+
+function normaliseTag(tag: string | undefined): string {
+  return typeof tag === "string" ? tag.trim().toLowerCase() : "";
+}
+
+function buildPlanSummary(entries: PlanEntry[]): PlanSummary {
+  let covered = 0;
+  let missing = 0;
+  let notApplicable = 0;
+  for (const entry of entries) {
+    if (entry.status === "covered") covered += 1;
+    else if (entry.status === "missing") missing += 1;
+    else notApplicable += 1;
+  }
+  return {
+    total: entries.length,
+    covered,
+    missing,
+    notApplicable,
+  };
+}
+
+function buildReportSummary(entries: ReportEntry[]): {
+  evaluated: number;
+  pass: number;
+  missing: number;
+  notApplicable: number;
+} {
+  let pass = 0;
+  let missing = 0;
+  let notApplicable = 0;
+  for (const entry of entries) {
+    if (entry.status === "pass") pass += 1;
+    else if (entry.status === "missing") missing += 1;
+    else notApplicable += 1;
+  }
+  return {
+    evaluated: entries.length,
+    pass,
+    missing,
+    notApplicable,
+  };
+}
+
+function formatPlanStatus(status: PlanStatus): string {
+  switch (status) {
+    case "covered":
+      return "✅ covered";
+    case "missing":
+      return "❌ missing";
+    default:
+      return "⚪ not applicable";
+  }
+}
+
+function formatReportStatus(status: ReportStatus): string {
+  switch (status) {
+    case "pass":
+      return "✅";
+    case "missing":
+      return "❌";
+    default:
+      return "⚪";
+  }
+}

--- a/packages/speckit-cli/src/services/compliance/index.ts
+++ b/packages/speckit-cli/src/services/compliance/index.ts
@@ -1,0 +1,13 @@
+export {
+  generateEduUsPlan,
+  verifyEduUsPlan,
+  renderEduUsPlanMarkdown,
+  renderEduUsReportMarkdown,
+} from "./edu-us.js";
+export type {
+  EduUsPlan,
+  EduUsReport,
+  ComplianceArtifact,
+  ComplianceReference,
+  ComplianceSeverity,
+} from "./edu-us.js";

--- a/packages/speckit-cli/test/compliance.test.ts
+++ b/packages/speckit-cli/test/compliance.test.ts
@@ -1,0 +1,147 @@
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { test } from "node:test";
+import fs from "fs-extra";
+import {
+  generateEduUsPlan,
+  verifyEduUsPlan,
+  renderEduUsPlanMarkdown,
+  renderEduUsReportMarkdown,
+} from "../src/services/compliance/edu-us.js";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../../..");
+const SCHEMA_PATH = path.join(REPO_ROOT, ".speckit", "schema", "spec.schema.json");
+
+const SPEC_YAML = `dialect:
+  id: speckit.v1
+  version: 1.0.0
+spec:
+  meta:
+    id: demo
+    title: Demo Compliance Spec
+    version: "1.0.0"
+  requirements:
+    - id: FERPA-DISCLOSURE
+      title: Disclosure logging
+      tags: ["ferpa:disclosure-controls"]
+    - id: FERPA-DIRECTORY
+      title: Directory information policy
+      tags: ["ferpa:directory-info"]
+    - id: FERPA-ACCESS
+      title: Access and amendment rights
+      tags: ["ferpa:access-rights"]
+    - id: COPPA-SCOPE
+      title: Child-directed service
+      tags: ["coppa:under-13"]
+    - id: COPPA-CONSENT
+      title: Parental consent process
+      tags: ["coppa:parental-consent"]
+    - id: COPPA-NOTICE
+      title: Direct notice template
+      tags: ["coppa:direct-notice"]
+    - id: COPPA-RETENTION
+      title: Retention schedule
+      tags: ["coppa:data-retention"]
+    - id: CIPA-POLICY
+      title: Filtering policy
+      tags: ["cipa:e-rate", "cipa:filtering"]
+    - id: PPRA-SURVEYS
+      title: Sensitive survey approvals
+      tags: ["ppra:sensitive-surveys"]
+    - id: PPRA-PARENT
+      title: Parental opt-out
+      tags: ["ppra:parent-rights"]
+    - id: CA-ADS
+      title: SOPIPA advertising ban
+      tags: ["ca:sopipa:ads"]
+    - id: CA-PROFILE
+      title: SOPIPA profiling controls
+      tags: ["ca:sopipa:profiling"]
+    - id: CA-SALE
+      title: SOPIPA data sale prohibition
+      tags: ["ca:sopipa:sale"]
+    - id: CA-DELETION
+      title: SOPIPA deletion workflows
+      tags: ["ca:sopipa:deletion"]
+    - id: NY-PBOR
+      title: NY Parent Bill of Rights
+      tags: ["ny:2-d:parent-rights"]
+    - id: NY-POLICY
+      title: NY privacy policy
+      tags: ["ny:2-d:privacy-policy"]
+    - id: NY-DPO
+      title: NY Data Protection Officer
+      tags: ["ny:2-d:dpo"]
+    - id: NY-CONTRACTS
+      title: NY contract disclosures
+      tags: ["ny:2-d:contracts"]
+`;
+
+const ARTIFACT_PATHS = [
+  "docs/compliance/edu-us/ferpa/disclosure-logging.md",
+  "docs/compliance/edu-us/ferpa/directory-information-policy.md",
+  "docs/compliance/edu-us/ferpa/access-request-procedure.md",
+  "docs/compliance/edu-us/coppa/parental-consent-procedure.md",
+  "docs/compliance/edu-us/coppa/direct-notice-template.md",
+  "docs/compliance/edu-us/coppa/data-retention-schedule.md",
+  "docs/compliance/edu-us/cipa/filtering-monitoring-policy.md",
+  "docs/compliance/edu-us/ppra/sensitive-survey-approvals.md",
+  "docs/compliance/edu-us/ppra/parental-notification-opt-out.md",
+  "docs/compliance/edu-us/state/ca-sopipa/advertising-ban.md",
+  "docs/compliance/edu-us/state/ca-sopipa/profiling-restrictions.md",
+  "docs/compliance/edu-us/state/ca-sopipa/data-sale-prohibition.md",
+  "docs/compliance/edu-us/state/ca-sopipa/deletion-requests.md",
+  "docs/compliance/edu-us/state/ny-2d/parent-bill-of-rights.md",
+  "docs/compliance/edu-us/state/ny-2d/data-privacy-security-policy.md",
+  "docs/compliance/edu-us/state/ny-2d/data-protection-officer.md",
+  "docs/compliance/edu-us/state/ny-2d/third-party-contracts.md",
+];
+
+test("generateEduUsPlan maps tags and overlays", async () => {
+  const repoRoot = await setupRepo();
+  try {
+    const plan = await generateEduUsPlan({ repoRoot, overlays: ["ca-sopipa", "ny-2d"] });
+    assert.equal(plan.framework, "edu-us");
+    assert.equal(plan.summary.total, 17);
+    assert.equal(plan.summary.covered, 17);
+    const ferpa = plan.obligations.find(item => item.id === "ferpa-directory-information");
+    assert.ok(ferpa);
+    assert.equal(ferpa?.status, "covered");
+    assert.ok(ferpa?.matches.some(match => match.id === "FERPA-DIRECTORY"));
+    const markdown = renderEduUsPlanMarkdown(plan);
+    assert.ok(markdown.includes("Education (US) Compliance Plan"));
+  } finally {
+    await fs.remove(repoRoot);
+  }
+});
+
+test("verifyEduUsPlan reports passes when evidence exists", async () => {
+  const repoRoot = await setupRepo();
+  try {
+    for (const relPath of ARTIFACT_PATHS) {
+      const target = path.join(repoRoot, relPath);
+      await fs.outputFile(target, "# artifact\n", "utf8");
+    }
+    const plan = await generateEduUsPlan({ repoRoot, overlays: ["ca-sopipa", "ny-2d"] });
+    const report = await verifyEduUsPlan(plan, { repoRoot });
+    assert.equal(report.summary.missing, 0);
+    assert.equal(report.summary.pass, plan.summary.covered);
+    assert.equal(report.alerts.length, 0);
+    const markdown = renderEduUsReportMarkdown(report);
+    assert.ok(markdown.includes("Compliance Report"));
+  } finally {
+    await fs.remove(repoRoot);
+  }
+});
+
+async function setupRepo(): Promise<string> {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), "speckit-edu-us-"));
+  const specDir = path.join(tmpRoot, ".speckit");
+  await fs.ensureDir(path.join(specDir, "schema"));
+  await fs.copyFile(SCHEMA_PATH, path.join(specDir, "schema", "spec.schema.json"));
+  await fs.writeFile(path.join(specDir, "spec.yaml"), SPEC_YAML, "utf8");
+  return tmpRoot;
+}

--- a/policy/opa/edu-us/cipa.rego
+++ b/policy/opa/edu-us/cipa.rego
@@ -1,0 +1,25 @@
+package speckit.edu_us.cipa
+
+# Input schema expectation:
+# {
+#   "framework": "edu-us",
+#   "context": {
+#     "cipa": {
+#       "claims_e_rate": bool
+#     }
+#   },
+#   "evidence": {
+#     "cipa": {
+#       "filtering_policy": bool
+#     }
+#   }
+# }
+
+# Require an internet safety policy and filtering/monitoring documentation
+# whenever a project claims E-Rate eligibility under CIPA.
+violation[msg] {
+  input.framework == "edu-us"
+  input.context.cipa.claims_e_rate
+  not input.evidence.cipa.filtering_policy
+  msg := "CIPA compliance requires a published filtering and monitoring policy for E-Rate eligibility."
+}

--- a/policy/opa/edu-us/coppa.rego
+++ b/policy/opa/edu-us/coppa.rego
@@ -1,0 +1,43 @@
+package speckit.edu_us.coppa
+
+# Input schema expectation:
+# {
+#   "framework": "edu-us",
+#   "context": {
+#     "coppa": {
+#       "processes_under_13": bool
+#     }
+#   },
+#   "evidence": {
+#     "coppa": {
+#       "parental_consent": bool,
+#       "direct_notice": bool,
+#       "retention_schedule": bool
+#     }
+#   }
+# }
+
+# Flag when a product processes data from children under 13 but
+# has not captured verifiable parental consent evidence.
+violation[msg] {
+  input.framework == "edu-us"
+  input.context.coppa.processes_under_13
+  not input.evidence.coppa.parental_consent
+  msg := "COPPA requires verifiable parental consent before collecting personal information from children under 13."
+}
+
+# Flag when parental notices are missing for child-directed features.
+violation[msg] {
+  input.framework == "edu-us"
+  input.context.coppa.processes_under_13
+  not input.evidence.coppa.direct_notice
+  msg := "COPPA direct notice to parents must be delivered before enabling child accounts."
+}
+
+# Flag if retention limits are undefined when handling child data.
+violation[msg] {
+  input.framework == "edu-us"
+  input.context.coppa.processes_under_13
+  not input.evidence.coppa.retention_schedule
+  msg := "COPPA requires an articulated retention and deletion schedule for child personal information."
+}

--- a/policy/opa/edu-us/ny-2d.rego
+++ b/policy/opa/edu-us/ny-2d.rego
@@ -1,0 +1,31 @@
+package speckit.edu_us.ny_2d
+
+# Input schema expectation:
+# {
+#   "framework": "edu-us",
+#   "context": {
+#     "ny_2d": {
+#       "integrates_with_districts": bool
+#     }
+#   },
+#   "evidence": {
+#     "ny_2d": {
+#       "parent_bill_of_rights": bool,
+#       "privacy_security_policy": bool
+#     }
+#   }
+# }
+
+violation[msg] {
+  input.framework == "edu-us"
+  input.context.ny_2d.integrates_with_districts
+  not input.evidence.ny_2d.parent_bill_of_rights
+  msg := "New York Education Law 2-d requires a posted Parent Bill of Rights for Data Privacy and Security."
+}
+
+violation[msg] {
+  input.framework == "edu-us"
+  input.context.ny_2d.integrates_with_districts
+  not input.evidence.ny_2d.privacy_security_policy
+  msg := "New York Education Law 2-d requires a published Data Privacy and Security Policy before contracting with districts."
+}


### PR DESCRIPTION
## Summary
- add education compliance checklists for FERPA, COPPA, CIPA, and PPRA plus California SOPIPA and New York Ed Law 2-d overlays
- introduce CLI compliance plan and verify commands backed by new edu-us mapping and OPA guardrails
- document the secure education workflow in the README and cover the new flow with integration tests

## Testing
- pnpm --filter @speckit/cli exec tsx --test test/template.test.ts test/compliance.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68d4707ba5a8832490d334709cb004a6