### PR TITLE
feat: gate secure mode behind experimental flag

### DIFF
--- a/.github/workflows/experimental-and-graduation-guard.yml
+++ b/.github/workflows/experimental-and-graduation-guard.yml
@@ -1,0 +1,81 @@
+name: experimental-and-graduation-guard
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened, labeled, unlabeled]
+
+jobs:
+  guard:
+    runs-on: ubuntu-latest
+    env:
+      HAS_EXPERIMENTAL_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'experimental:allowed') }}
+      HAS_GRADUATION_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'graduation:approved') }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect changes
+        id: diff
+        run: |
+          base=origin/${{ github.base_ref }}
+          git fetch origin ${{ github.base_ref }} --depth=1
+          git diff --name-only $base...HEAD > changed.txt
+          echo "files<<EOF" >> "$GITHUB_OUTPUT"
+          cat changed.txt >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          cat changed.txt
+      - name: Guard experimental default flip
+        if: contains(steps.diff.outputs.files, 'packages/speckit-cli/src/config/featureFlags.ts')
+        run: |
+          base=origin/${{ github.base_ref }}
+          git show $base:packages/speckit-cli/src/config/featureFlags.ts > before.ts
+          cat packages/speckit-cli/src/config/featureFlags.ts > after.ts
+          before=$(grep -E 'experimental\.enabled\s*=\s*(true|false)' before.ts | head -n1 || true)
+          after=$(grep -E 'experimental\.enabled\s*=\s*(true|false)' after.ts | head -n1 || true)
+          echo "Before: $before"
+          echo "After : $after"
+          if [ "${HAS_EXPERIMENTAL_LABEL}" != "true" ] && echo "$before" | grep -q 'false' && echo "$after" | grep -q 'true'; then
+            echo "Experimental default enabled. Require label 'experimental:allowed'."
+            exit 1
+          fi
+      - name: Guard framework status flips
+        if: contains(steps.diff.outputs.files, 'packages/speckit-cli/src/config/frameworkRegistry.ts')
+        run: |
+          base=origin/${{ github.base_ref }}
+          git show $base:packages/speckit-cli/src/config/frameworkRegistry.ts > before.ts
+          cp packages/speckit-cli/src/config/frameworkRegistry.ts after.ts
+          node <<'NODE'
+          const fs = require('fs');
+          const before = fs.readFileSync('before.ts', 'utf8');
+          const after = fs.readFileSync('after.ts', 'utf8');
+          const regex = /(hipaa|gdpr|soc2|iso27001|edu-us|edu-eu-ie)"?\s*:\s*\{[\s\S]*?status:\s*"(experimental|ga)"/g;
+          const extract = (src) => {
+            const result = {};
+            let match;
+            while ((match = regex.exec(src)) !== null) {
+              result[match[1]] = match[2];
+            }
+            return result;
+          };
+          const beforeMap = extract(before);
+          const afterMap = extract(after);
+          const hasGraduationLabel = process.env.HAS_GRADUATION_LABEL === 'true';
+          let failure = false;
+          for (const id of Object.keys(afterMap)) {
+            if (!beforeMap[id]) continue;
+            if (beforeMap[id] === afterMap[id]) continue;
+            if (beforeMap[id] === 'experimental' && afterMap[id] === 'ga') {
+              if (!hasGraduationLabel) {
+                console.log(`Framework ${id} graduated to GA. Require label 'graduation:approved'.`);
+                failure = true;
+              }
+            } else if (beforeMap[id] === 'ga' && afterMap[id] === 'experimental') {
+              if (!hasGraduationLabel) {
+                console.log(`Regression detected for ${id} (ga -> experimental). Require label 'graduation:approved'.`);
+                failure = true;
+              }
+            }
+          }
+          if (failure) process.exit(1);
+          NODE
+          rm -f before.ts after.ts

--- a/README.md
+++ b/README.md
@@ -77,13 +77,21 @@ pnpm --filter @speckit/tui dev
 #   S → Settings (toggle AI/analytics, edit provider, keys, models, repo paths)
 ```
 
-> #### Choose a mode
+> #### Modes & experimental gate
 > ```bash
-> speckit init --mode classic   # default
-> speckit init --mode secure
+> # Classic is default
+> speckit init --mode classic
+>
+> # Try Secure (experimental)
+> speckit init --experimental --mode secure
+> speckit frameworks list
 > ```
 
 Classic keeps things lightweight with no external framework dependencies. Secure enables hardened scaffolds and standards enforcement; pass `--mode secure` whenever you need the guardrails.
+
+### Framework statuses (GA vs Experimental)
+
+Compliance frameworks now flow through a central registry so each standard can graduate independently. Run `speckit frameworks list` to see the current status badges (GA or Experimental) and which ones require the experimental gate. GA frameworks work without `--experimental`; experimental ones stay locked until you opt in with `--experimental`, `SPECKIT_EXPERIMENTAL=1`, or a project/user config toggle.
 
 ### Secure mode: HIPAA compliance pack
 
@@ -96,8 +104,8 @@ Secure initiatives can now opt into a curated HIPAA Security Rule workflow witho
 Then run the compliance helpers:
 
 ```bash
-speckit compliance plan --framework hipaa    # generates the HIPAA checklist, privacy role guide, and breach plan
-speckit compliance verify --framework hipaa  # evaluates safeguards, runs the OPA policy, and writes .speckit/compliance-report.*
+speckit compliance plan --experimental --framework hipaa    # generates the HIPAA checklist, privacy role guide, and breach plan
+speckit compliance verify --experimental --framework hipaa  # evaluates safeguards, runs the OPA policy, and writes .speckit/compliance-report.*
 ```
 
 The HIPAA catalog uses NIST SP 800-66 Rev.2 guidance and the OLIR HIPAA ↔︎ NIST SP 800-53 Rev.5 mapping. Objective technical safeguards (TLS enforcement, encryption at rest, unique user IDs, audit logging) must report `pass` or the verify step fails; all other safeguards surface as manual evidence for reviewers.
@@ -107,8 +115,8 @@ The HIPAA catalog uses NIST SP 800-66 Rev.2 guidance and the OLIR HIPAA ↔︎ N
 K–12 initiatives can opt into a FERPA/COPPA/CIPA/PPRA workflow with optional state overlays for California SOPIPA and New York Education Law 2-d. Generate the bundle, capture evidence, and run policy checks:
 
 ```bash
-speckit compliance plan --framework edu-us --overlays ca-sopipa,ny-2d
-speckit compliance verify --framework edu-us
+speckit compliance plan --experimental --framework edu-us --overlays ca-sopipa,ny-2d
+speckit compliance verify --experimental --framework edu-us
 ```
 
 - `plan` writes `docs/internal/compliance/edu-us/**`, including the FERPA, COPPA, CIPA, PPRA checklists and any overlays you request.
@@ -121,8 +129,8 @@ The generated README links to primary guidance from the U.S. Department of Educa
 Opt into an EU/Ireland bundle when processing student data for Irish schools or EU programmes that follow the Data Protection Commission’s guidance.
 
 ```bash
-speckit compliance plan --framework edu-eu-ie
-speckit compliance verify --framework edu-eu-ie
+speckit compliance plan --experimental --framework edu-eu-ie
+speckit compliance verify --experimental --framework edu-eu-ie
 ```
 
 - `plan` writes GDPR and DPC fundamentals docs to `docs/internal/compliance/edu-eu-ie/**` and seeds an evidence tracker that reflects your configured age of digital consent.

--- a/packages/speckit-cli/src/cli.ts
+++ b/packages/speckit-cli/src/cli.ts
@@ -10,6 +10,8 @@ import { GenerateDocsCommand } from "./commands/gen.js";
 import { AuditCommand } from "./commands/audit.js";
 import { DoctorCommand } from "./commands/doctor.js";
 import { CompliancePlanCommand, ComplianceVerifyCommand } from "./commands/compliance.js";
+import { FrameworksListCommand } from "./commands/frameworks.js";
+import { ConfigPrintCommand } from "./commands/config.js";
 
 const [, , ...args] = process.argv;
 
@@ -38,5 +40,7 @@ cli.register(AuditCommand);
 cli.register(DoctorCommand);
 cli.register(CompliancePlanCommand);
 cli.register(ComplianceVerifyCommand);
+cli.register(FrameworksListCommand);
+cli.register(ConfigPrintCommand);
 
 cli.runExit(args, Cli.defaultContext);

--- a/packages/speckit-cli/src/commands/base.ts
+++ b/packages/speckit-cli/src/commands/base.ts
@@ -1,0 +1,28 @@
+import { Command, Option } from "clipanion";
+import type { FeatureFlags, CliArgs } from "../config/featureFlags.js";
+import { getFlags } from "../config/featureFlags.js";
+
+export abstract class SpeckitCommand extends Command {
+  experimentalFlag = Option.Boolean("--experimental", false);
+
+  noExperimentalFlag = Option.Boolean("--no-experimental", false);
+
+  protected resolveFeatureFlags(extra?: Partial<CliArgs>): FeatureFlags {
+    const cliArgs = this.buildCliArgs(extra);
+    return getFlags(cliArgs);
+  }
+
+  protected buildCliArgs(extra?: Partial<CliArgs>): CliArgs {
+    const args: CliArgs = { cwd: process.cwd() };
+    if (this.experimentalFlag) {
+      args.experimental = true;
+    }
+    if (this.noExperimentalFlag) {
+      args.noExperimental = true;
+    }
+    if (extra) {
+      return { ...args, ...extra };
+    }
+    return args;
+  }
+}

--- a/packages/speckit-cli/src/commands/compliance.ts
+++ b/packages/speckit-cli/src/commands/compliance.ts
@@ -1,7 +1,10 @@
-import { Command, Option } from "clipanion";
+import { Option } from "clipanion";
 import { runCompliancePlan, runComplianceVerify } from "../services/compliance/index.js";
+import { assertFrameworksAllowed, FRAMEWORKS, type FrameworkId } from "../config/frameworkRegistry.js";
+import { assertModeAllowed } from "../config/featureFlags.js";
+import { SpeckitCommand } from "./base.js";
 
-export class CompliancePlanCommand extends Command {
+export class CompliancePlanCommand extends SpeckitCommand {
   static paths = [["compliance", "plan"]];
 
   framework = Option.String("--framework");
@@ -10,6 +13,26 @@ export class CompliancePlanCommand extends Command {
   async execute() {
     if (!this.framework) {
       this.context.stderr.write("speckit compliance plan failed: --framework is required\n");
+      return 1;
+    }
+    const flags = this.resolveFeatureFlags();
+    try {
+      assertModeAllowed("secure", flags);
+    } catch (error: any) {
+      const message = error?.message ?? String(error);
+      this.context.stderr.write(`speckit compliance plan failed: ${message}\n`);
+      return 1;
+    }
+    const frameworkId = this.framework as FrameworkId;
+    if (!Object.prototype.hasOwnProperty.call(FRAMEWORKS, frameworkId)) {
+      this.context.stderr.write(`speckit compliance plan failed: Unknown framework '${this.framework}'\n`);
+      return 1;
+    }
+    try {
+      assertFrameworksAllowed([frameworkId], flags);
+    } catch (error: any) {
+      const message = error?.message ?? String(error);
+      this.context.stderr.write(`speckit compliance plan failed: ${message}\n`);
       return 1;
     }
     try {
@@ -28,7 +51,7 @@ export class CompliancePlanCommand extends Command {
   }
 }
 
-export class ComplianceVerifyCommand extends Command {
+export class ComplianceVerifyCommand extends SpeckitCommand {
   static paths = [["compliance", "verify"]];
 
   framework = Option.String("--framework");
@@ -37,6 +60,26 @@ export class ComplianceVerifyCommand extends Command {
   async execute() {
     if (!this.framework) {
       this.context.stderr.write("speckit compliance verify failed: --framework is required\n");
+      return 1;
+    }
+    const flags = this.resolveFeatureFlags();
+    try {
+      assertModeAllowed("secure", flags);
+    } catch (error: any) {
+      const message = error?.message ?? String(error);
+      this.context.stderr.write(`speckit compliance verify failed: ${message}\n`);
+      return 1;
+    }
+    const frameworkId = this.framework as FrameworkId;
+    if (!Object.prototype.hasOwnProperty.call(FRAMEWORKS, frameworkId)) {
+      this.context.stderr.write(`speckit compliance verify failed: Unknown framework '${this.framework}'\n`);
+      return 1;
+    }
+    try {
+      assertFrameworksAllowed([frameworkId], flags);
+    } catch (error: any) {
+      const message = error?.message ?? String(error);
+      this.context.stderr.write(`speckit compliance verify failed: ${message}\n`);
       return 1;
     }
     try {

--- a/packages/speckit-cli/src/commands/config.ts
+++ b/packages/speckit-cli/src/commands/config.ts
@@ -1,0 +1,41 @@
+import { Option } from "clipanion";
+import { SpeckitCommand } from "./base.js";
+import { isExperimentalEnabled } from "../config/featureFlags.js";
+
+export class ConfigPrintCommand extends SpeckitCommand {
+  static paths = [["config", "print"]];
+
+  json = Option.Boolean("--json", false);
+
+  async execute() {
+    const flags = this.resolveFeatureFlags();
+    const experimentalOn = isExperimentalEnabled(flags);
+
+    if (this.json) {
+      this.context.stdout.write(`${JSON.stringify({ featureFlags: flags }, null, 2)}\n`);
+      return 0;
+    }
+
+    this.context.stdout.write("Speckit Configuration\n======================\n\n");
+    this.context.stdout.write(`Experimental gate: ${experimentalOn ? "ENABLED" : "DISABLED"}\n`);
+    this.context.stdout.write("Modes:\n");
+    this.context.stdout.write(
+      `  - classic: experimental=${String(flags.modes.classic.experimental)}\n`
+    );
+    this.context.stdout.write(
+      `  - secure: experimental=${String(flags.modes.secure.experimental)}\n`
+    );
+    this.context.stdout.write("\nExperimental feature toggles:\n");
+    const featureEntries = Object.entries(flags.experimental.features);
+    if (featureEntries.length === 0) {
+      this.context.stdout.write("  (none configured)\n");
+    } else {
+      for (const [key, value] of featureEntries) {
+        this.context.stdout.write(`  - ${key}: ${value ? "enabled" : "disabled"}\n`);
+      }
+    }
+    this.context.stdout.write("\nUse --json for a machine-readable view.\n");
+
+    return 0;
+  }
+}

--- a/packages/speckit-cli/src/commands/frameworks.ts
+++ b/packages/speckit-cli/src/commands/frameworks.ts
@@ -1,0 +1,60 @@
+import { Option } from "clipanion";
+import { SpeckitCommand } from "./base.js";
+import { FRAMEWORKS, isFrameworkAllowed } from "../config/frameworkRegistry.js";
+import { isExperimentalEnabled } from "../config/featureFlags.js";
+
+export class FrameworksListCommand extends SpeckitCommand {
+  static paths = [["frameworks", "list"]];
+
+  json = Option.Boolean("--json", false);
+
+  async execute() {
+    const flags = this.resolveFeatureFlags();
+    const experimentalOn = isExperimentalEnabled(flags);
+    const entries = Object.values(FRAMEWORKS).map(meta => ({
+      id: meta.id,
+      title: meta.title,
+      status: meta.status,
+      tags: [...meta.tags],
+      bundles: [...meta.bundles],
+      allowed: isFrameworkAllowed(meta.id, flags),
+    }));
+
+    if (this.json) {
+      this.context.stdout.write(
+        `${JSON.stringify({ experimental: flags.experimental, frameworks: entries }, null, 2)}\n`
+      );
+      return 0;
+    }
+
+    this.context.stdout.write("Speckit Framework Registry\n===========================\n\n");
+    this.context.stdout.write(
+      `Experimental gate: ${experimentalOn ? "ENABLED" : "DISABLED"}\n\n`
+    );
+    for (const entry of entries) {
+      const badge = entry.status === "ga" ? "[GA]" : "[Experimental]";
+      const availability = entry.allowed
+        ? "available"
+        : "locked — enable with --experimental or SPECKIT_EXPERIMENTAL=1";
+      this.context.stdout.write(
+        `- ${entry.id.padEnd(8)} ${badge} ${entry.title} — ${availability}\n`
+      );
+      if (entry.tags.length) {
+        this.context.stdout.write(`  tags: ${entry.tags.join(", ")}\n`);
+      }
+      if (entry.bundles.length) {
+        this.context.stdout.write(`  bundles: ${entry.bundles.join(", ")}\n`);
+      }
+      this.context.stdout.write("\n");
+    }
+
+    if (!experimentalOn) {
+      this.context.stdout.write(
+        "Experimental frameworks are locked. Re-run with --experimental, set SPECKIT_EXPERIMENTAL=1, " +
+          "or configure settings.experimental.enabled: true.\n"
+      );
+    }
+
+    return 0;
+  }
+}

--- a/packages/speckit-cli/src/config/featureFlags.ts
+++ b/packages/speckit-cli/src/config/featureFlags.ts
@@ -1,0 +1,171 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import YAML from "yaml";
+
+export interface FeatureFlags {
+  experimental: { enabled: boolean; features: Record<string, boolean> };
+  modes: {
+    classic: { experimental: false };
+    secure: { experimental: boolean };
+  };
+}
+
+export interface CliArgs {
+  cwd?: string;
+  experimental?: boolean;
+  noExperimental?: boolean;
+  experimentalFeatures?: Record<string, boolean> | string[] | string | null;
+}
+
+const DEFAULT_FEATURE_FLAGS: FeatureFlags = {
+  experimental: { enabled: false, features: {} },
+  modes: {
+    classic: { experimental: false },
+    secure: { experimental: true },
+  },
+};
+
+const USER_CONFIG_PATH = path.join(os.homedir(), ".config", "speckit", "config.yaml");
+const PROJECT_CONFIG_FILENAME = "speckit.config.yaml";
+
+function cloneDefaults(): FeatureFlags {
+  return {
+    experimental: {
+      enabled: DEFAULT_FEATURE_FLAGS.experimental.enabled,
+      features: { ...DEFAULT_FEATURE_FLAGS.experimental.features },
+    },
+    modes: {
+      classic: { ...DEFAULT_FEATURE_FLAGS.modes.classic },
+      secure: { ...DEFAULT_FEATURE_FLAGS.modes.secure },
+    },
+  };
+}
+
+function parseBoolean(value: unknown): boolean | null {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized) return null;
+    if (["1", "true", "t", "yes", "y", "on", "enable", "enabled"].includes(normalized)) {
+      return true;
+    }
+    if (["0", "false", "f", "no", "n", "off", "disable", "disabled"].includes(normalized)) {
+      return false;
+    }
+  }
+  return null;
+}
+
+function readYamlFile(filePath: string): any {
+  try {
+    if (!fs.existsSync(filePath)) {
+      return null;
+    }
+    const raw = fs.readFileSync(filePath, "utf8");
+    if (!raw.trim()) {
+      return null;
+    }
+    return YAML.parse(raw);
+  } catch {
+    return null;
+  }
+}
+
+function applyFeatureMap(target: Record<string, boolean>, source: unknown): void {
+  if (!source || typeof source !== "object") {
+    return;
+  }
+  for (const [key, value] of Object.entries(source as Record<string, unknown>)) {
+    const normalizedKey = typeof key === "string" ? key.trim() : String(key);
+    if (!normalizedKey) continue;
+    const parsed = parseBoolean(value);
+    if (parsed === null) continue;
+    target[normalizedKey] = parsed;
+  }
+}
+
+function applyFeaturesList(target: Record<string, boolean>, value: string[] | string | null | undefined): void {
+  if (!value) return;
+  const list = Array.isArray(value)
+    ? value.map(entry => (typeof entry === "string" ? entry : String(entry))).filter(Boolean)
+    : String(value)
+        .split(",")
+        .map(entry => entry.trim())
+        .filter(Boolean);
+  for (const key of list) {
+    target[key] = true;
+  }
+}
+
+function mergeExperimentalFlags(flags: FeatureFlags, input: any): void {
+  if (!input || typeof input !== "object") {
+    return;
+  }
+  const enabled = parseBoolean((input as any).enabled);
+  if (enabled !== null) {
+    flags.experimental.enabled = enabled;
+  }
+  applyFeatureMap(flags.experimental.features, (input as any).features);
+  if (input.modes && typeof input.modes === "object") {
+    const modes = input.modes as Record<string, any>;
+    if (modes.secure && typeof modes.secure === "object") {
+      const secureExperimental = parseBoolean(modes.secure.experimental);
+      if (secureExperimental !== null) {
+        flags.modes.secure.experimental = secureExperimental;
+      }
+    }
+  }
+}
+
+export function getFlags(cliArgs: CliArgs): FeatureFlags {
+  const flags = cloneDefaults();
+  const cwd = cliArgs.cwd ? path.resolve(cliArgs.cwd) : process.cwd();
+
+  const userConfig = readYamlFile(USER_CONFIG_PATH);
+  mergeExperimentalFlags(flags, userConfig?.settings?.experimental ?? userConfig?.experimental);
+
+  const projectConfigPath = path.join(cwd, ".speckit", PROJECT_CONFIG_FILENAME);
+  const projectConfig = readYamlFile(projectConfigPath);
+  mergeExperimentalFlags(flags, projectConfig?.settings?.experimental ?? projectConfig?.experimental);
+
+  const envExperimental = parseBoolean(process.env.SPECKIT_EXPERIMENTAL);
+  if (envExperimental !== null) {
+    flags.experimental.enabled = envExperimental;
+  }
+  applyFeaturesList(flags.experimental.features, process.env.SPECKIT_EXPERIMENTAL_FEATURES ?? null);
+
+  if (cliArgs.experimental === true) {
+    flags.experimental.enabled = true;
+  }
+  if (cliArgs.noExperimental === true) {
+    flags.experimental.enabled = false;
+  }
+  applyFeaturesList(flags.experimental.features, cliArgs.experimentalFeatures ?? null);
+
+  return flags;
+}
+
+export function isExperimentalEnabled(flags: FeatureFlags): boolean {
+  return flags.experimental.enabled === true;
+}
+
+export function assertModeAllowed(mode: "classic" | "secure", flags: FeatureFlags): void {
+  if (mode === "classic") {
+    return;
+  }
+  if (flags.modes.secure.experimental && !isExperimentalEnabled(flags)) {
+    const hint =
+      "Secure mode is experimental. Enable experimental features with `--experimental`, " +
+      "set SPECKIT_EXPERIMENTAL=1, or update settings.experimental.enabled to true.";
+    throw new Error(hint);
+  }
+}
+
+export { DEFAULT_FEATURE_FLAGS };

--- a/packages/speckit-cli/src/config/frameworkRegistry.ts
+++ b/packages/speckit-cli/src/config/frameworkRegistry.ts
@@ -1,0 +1,89 @@
+import { FeatureFlags, isExperimentalEnabled } from "./featureFlags.js";
+
+export type FrameworkId =
+  | "hipaa"
+  | "gdpr"
+  | "soc2"
+  | "iso27001"
+  | "edu-us"
+  | "edu-eu-ie";
+
+export type FrameworkStatus = "experimental" | "ga";
+
+export interface FrameworkMeta {
+  id: FrameworkId;
+  title: string;
+  status: FrameworkStatus;
+  tags: string[];
+  bundles: string[];
+}
+
+export const FRAMEWORKS: Record<FrameworkId, FrameworkMeta> = {
+  hipaa: {
+    id: "hipaa",
+    title: "HIPAA (US Healthcare)",
+    status: "experimental",
+    tags: ["secure", "health"],
+    bundles: ["compliance/hipaa"],
+  },
+  gdpr: {
+    id: "gdpr",
+    title: "GDPR (EU/EEA)",
+    status: "experimental",
+    tags: ["secure", "privacy"],
+    bundles: ["compliance/gdpr-core"],
+  },
+  soc2: {
+    id: "soc2",
+    title: "SOC 2 (AICPA)",
+    status: "experimental",
+    tags: ["secure", "trust"],
+    bundles: ["compliance/soc2-tsc"],
+  },
+  iso27001: {
+    id: "iso27001",
+    title: "ISO/IEC 27001",
+    status: "experimental",
+    tags: ["secure", "ism"],
+    bundles: ["compliance/iso27001-annex-a"],
+  },
+  "edu-us": {
+    id: "edu-us",
+    title: "Education (US: FERPA/COPPA/CIPA/PPRA)",
+    status: "experimental",
+    tags: ["secure", "education", "us"],
+    bundles: ["compliance/edu-us/*"],
+  },
+  "edu-eu-ie": {
+    id: "edu-eu-ie",
+    title: "Education (EU/IE: GDPR + IE Fundamentals)",
+    status: "experimental",
+    tags: ["secure", "education", "eu"],
+    bundles: ["compliance/edu-eu/*", "compliance/edu-ie/*"],
+  },
+};
+
+export function isFrameworkAllowed(id: FrameworkId, flags: FeatureFlags): boolean {
+  const meta = FRAMEWORKS[id];
+  if (!meta) {
+    return false;
+  }
+  if (meta.status === "ga") {
+    return true;
+  }
+  return isExperimentalEnabled(flags);
+}
+
+export function assertFrameworksAllowed(ids: FrameworkId[], flags: FeatureFlags): void {
+  const uniqueIds = Array.from(new Set(ids));
+  const blocked = uniqueIds.filter(id => !isFrameworkAllowed(id, flags));
+  if (blocked.length === 0) {
+    return;
+  }
+  const names = blocked
+    .map(id => FRAMEWORKS[id]?.title ?? id)
+    .join(", ");
+  const hint =
+    "Enable experimental with `--experimental` (or via SPECKIT_EXPERIMENTAL/config) to try these frameworks.";
+  throw new Error(`Frameworks not available without Experimental: ${names}. ${hint}`);
+}

--- a/packages/speckit-cli/src/config/schema/feature-flags.schema.json
+++ b/packages/speckit-cli/src/config/schema/feature-flags.schema.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Speckit Feature Flags",
+  "type": "object",
+  "properties": {
+    "settings": {
+      "type": "object",
+      "properties": {
+        "experimental": {
+          "type": "object",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "features": {
+              "type": "object",
+              "additionalProperties": { "type": "boolean" }
+            },
+            "modes": {
+              "type": "object",
+              "properties": {
+                "secure": {
+                  "type": "object",
+                  "properties": {
+                    "experimental": { "type": "boolean" }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "additionalProperties": true
+}

--- a/packages/speckit-cli/src/index.ts
+++ b/packages/speckit-cli/src/index.ts
@@ -1,2 +1,15 @@
 export { useTemplateIntoDir } from "./services/template.js";
 export type { PostInitCommandEvent } from "./services/template.js";
+export {
+  getFlags,
+  isExperimentalEnabled,
+  assertModeAllowed,
+  DEFAULT_FEATURE_FLAGS,
+} from "./config/featureFlags.js";
+export type { FeatureFlags, CliArgs } from "./config/featureFlags.js";
+export {
+  FRAMEWORKS,
+  isFrameworkAllowed,
+  assertFrameworksAllowed,
+} from "./config/frameworkRegistry.js";
+export type { FrameworkId, FrameworkMeta, FrameworkStatus } from "./config/frameworkRegistry.js";

--- a/packages/speckit-cli/test/cli-gating.test.ts
+++ b/packages/speckit-cli/test/cli-gating.test.ts
@@ -1,0 +1,74 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { FrameworksListCommand } from "../src/commands/frameworks.js";
+import { CompliancePlanCommand } from "../src/commands/compliance.js";
+
+function createIo() {
+  let stdout = "";
+  let stderr = "";
+  return {
+    context: {
+      stdout: {
+        write(chunk: string) {
+          stdout += chunk;
+          return true;
+        },
+      },
+      stderr: {
+        write(chunk: string) {
+          stderr += chunk;
+          return true;
+        },
+      },
+    },
+    getStdout: () => stdout,
+    getStderr: () => stderr,
+    reset() {
+      stdout = "";
+      stderr = "";
+    },
+  };
+}
+
+test("frameworks list highlights experimental badges when gate is off", async () => {
+  const io = createIo();
+  const prev = process.env.SPECKIT_EXPERIMENTAL;
+  process.env.SPECKIT_EXPERIMENTAL = "0";
+  try {
+    const command = new FrameworksListCommand();
+    command.context = io.context as any;
+    const exitCode = await command.execute();
+    assert.equal(exitCode, 0);
+    const output = io.getStdout();
+    assert.match(output, /\[Experimental]/);
+    assert.match(output, /locked — enable with --experimental/);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.SPECKIT_EXPERIMENTAL;
+    } else {
+      process.env.SPECKIT_EXPERIMENTAL = prev;
+    }
+  }
+});
+
+test("compliance plan blocks secure mode when experimental is disabled", async () => {
+  const io = createIo();
+  const prev = process.env.SPECKIT_EXPERIMENTAL;
+  process.env.SPECKIT_EXPERIMENTAL = "0";
+  try {
+    const command = new CompliancePlanCommand();
+    command.context = io.context as any;
+    command.framework = "hipaa";
+    const exitCode = await command.execute();
+    assert.equal(exitCode, 1);
+    const stderr = io.getStderr();
+    assert.match(stderr, /speckit compliance plan failed: Secure mode is experimental/);
+  } finally {
+    if (prev === undefined) {
+      delete process.env.SPECKIT_EXPERIMENTAL;
+    } else {
+      process.env.SPECKIT_EXPERIMENTAL = prev;
+    }
+  }
+});
+

--- a/packages/speckit-cli/test/doctor.test.ts
+++ b/packages/speckit-cli/test/doctor.test.ts
@@ -1,0 +1,53 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { DoctorCommand } from "../src/commands/doctor.js";
+
+function createIo() {
+  let stdout = "";
+  let stderr = "";
+  return {
+    context: {
+      stdout: {
+        write(chunk: string) {
+          stdout += chunk;
+          return true;
+        },
+      },
+      stderr: {
+        write(chunk: string) {
+          stderr += chunk;
+          return true;
+        },
+      },
+    },
+    getStdout: () => stdout,
+    getStderr: () => stderr,
+  };
+}
+
+test("doctor --json reports experimental flags and frameworks", async () => {
+  const io = createIo();
+  const prev = process.env.SPECKIT_EXPERIMENTAL;
+  process.env.SPECKIT_EXPERIMENTAL = "0";
+  try {
+    const command = new DoctorCommand();
+    command.context = io.context as any;
+    command.json = true;
+    const exitCode = await command.execute();
+    // Doctor may warn about catalog policies; accept non-zero exit but require JSON payload.
+    assert.ok(exitCode === 0 || exitCode === 1);
+    const report = JSON.parse(io.getStdout());
+    assert.equal(report.default_mode, "classic");
+    assert.equal(typeof report.experimental?.enabled, "boolean");
+    assert.ok(Array.isArray(report.frameworks));
+    assert.ok(
+      report.frameworks.some((entry: any) => entry.status === "experimental" && entry.allowed === false)
+    );
+  } finally {
+    if (prev === undefined) {
+      delete process.env.SPECKIT_EXPERIMENTAL;
+    } else {
+      process.env.SPECKIT_EXPERIMENTAL = prev;
+    }
+  }
+});

--- a/packages/speckit-cli/test/framework-registry.test.ts
+++ b/packages/speckit-cli/test/framework-registry.test.ts
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { FRAMEWORKS, isFrameworkAllowed, assertFrameworksAllowed } from "../src/config/frameworkRegistry.js";
+import type { FeatureFlags } from "../src/config/featureFlags.js";
+import { DEFAULT_FEATURE_FLAGS } from "../src/config/featureFlags.js";
+
+test("GA frameworks remain available when experimental gate is off", () => {
+  const originalStatus = FRAMEWORKS.hipaa.status;
+  FRAMEWORKS.hipaa.status = "ga";
+  try {
+    const flags: FeatureFlags = {
+      experimental: { enabled: false, features: {} },
+      modes: {
+        classic: { experimental: DEFAULT_FEATURE_FLAGS.modes.classic.experimental },
+        secure: { experimental: DEFAULT_FEATURE_FLAGS.modes.secure.experimental },
+      },
+    };
+    assert.equal(isFrameworkAllowed("hipaa", flags), true);
+    assert.doesNotThrow(() => assertFrameworksAllowed(["hipaa"], flags));
+  } finally {
+    FRAMEWORKS.hipaa.status = originalStatus;
+  }
+});
+
+test("Experimental frameworks are blocked when the gate is off", () => {
+  const flags: FeatureFlags = {
+    experimental: { enabled: false, features: {} },
+    modes: {
+      classic: { experimental: DEFAULT_FEATURE_FLAGS.modes.classic.experimental },
+      secure: { experimental: DEFAULT_FEATURE_FLAGS.modes.secure.experimental },
+    },
+  };
+  assert.equal(isFrameworkAllowed("hipaa", flags), false);
+  assert.throws(
+    () => assertFrameworksAllowed(["hipaa"], flags),
+    /Frameworks not available without Experimental/
+  );
+});
+
+test("Experimental frameworks are allowed once the gate is enabled", () => {
+  const flags: FeatureFlags = {
+    experimental: { enabled: true, features: {} },
+    modes: {
+      classic: { experimental: DEFAULT_FEATURE_FLAGS.modes.classic.experimental },
+      secure: { experimental: DEFAULT_FEATURE_FLAGS.modes.secure.experimental },
+    },
+  };
+  assert.equal(isFrameworkAllowed("hipaa", flags), true);
+  assert.doesNotThrow(() => assertFrameworksAllowed(["hipaa"], flags));
+});

--- a/packages/speckit-gen-tests/src/__snapshots__/generator.snap.test.ts.snap
+++ b/packages/speckit-gen-tests/src/__snapshots__/generator.snap.test.ts.snap
@@ -9,6 +9,8 @@ speckit_provenance:
   tool_version: 0.1.0
   tool_commit: abc1234
   mode: classic
+  experimental: false
+  frameworks: []
   dialect:
     id: speckit.v1
     version: 1.1.0
@@ -69,6 +71,8 @@ speckit_provenance:
   tool_version: 0.1.0
   tool_commit: abc1234
   mode: classic
+  experimental: false
+  frameworks: []
   dialect:
     id: speckit.v1
     version: 1.1.0
@@ -97,6 +101,8 @@ speckit_provenance:
   tool_version: 0.1.0
   tool_commit: abc1234
   mode: classic
+  experimental: false
+  frameworks: []
   dialect:
     id: speckit.v1
     version: 1.1.0

--- a/packages/speckit-gen-tests/src/generator.snap.test.ts
+++ b/packages/speckit-gen-tests/src/generator.snap.test.ts
@@ -7,6 +7,7 @@ import { afterAll, describe, expect, it, vi } from "vitest";
 import type { SpecModel } from "../../speckit-core/src/model/SpecModel.js";
 import type { BundleDefinition, CatalogLockEntry } from "../../speckit-cli/src/services/catalog.js";
 import { generateDocs } from "../../speckit-cli/src/services/generator.js";
+import { DEFAULT_FEATURE_FLAGS } from "../../speckit-cli/src/config/featureFlags.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -92,7 +93,7 @@ describe("generator snapshots", () => {
     try {
       vi.setSystemTime(new Date("2024-01-02T03:04:05Z"));
       const repoRoot = await createRepoRoot();
-      await generateDocs({ repoRoot, write: true });
+      await generateDocs({ repoRoot, write: true, flags: DEFAULT_FEATURE_FLAGS });
       const markdown = await fs.readFile(path.join(repoRoot, "docs", "overview.md"), "utf8");
       expect(markdown).toMatchSnapshot();
     } finally {
@@ -105,7 +106,7 @@ describe("generator snapshots", () => {
     try {
       vi.setSystemTime(new Date("2024-01-02T03:04:05Z"));
       const repoRoot = await createRepoRoot();
-      await generateDocs({ repoRoot, write: true });
+      await generateDocs({ repoRoot, write: true, flags: DEFAULT_FEATURE_FLAGS });
       const yaml = await fs.readFile(path.join(repoRoot, "config", "app.yaml"), "utf8");
       expect(yaml).toMatchSnapshot();
     } finally {
@@ -118,7 +119,7 @@ describe("generator snapshots", () => {
     try {
       vi.setSystemTime(new Date("2024-01-02T03:04:05Z"));
       const repoRoot = await createRepoRoot();
-      await generateDocs({ repoRoot, write: true });
+      await generateDocs({ repoRoot, write: true, flags: DEFAULT_FEATURE_FLAGS });
       const tsContent = await fs.readFile(path.join(repoRoot, "src", "metadata.ts"), "utf8");
       expect(tsContent).toMatchSnapshot();
     } finally {
@@ -131,13 +132,13 @@ describe("generator snapshots", () => {
     try {
       const repoRoot = await createRepoRoot();
       vi.setSystemTime(new Date("2024-01-02T03:04:05Z"));
-      const first = await generateDocs({ repoRoot, write: true });
+      const first = await generateDocs({ repoRoot, write: true, flags: DEFAULT_FEATURE_FLAGS });
       expect(first.outputs.every(output => output.changed)).toBe(true);
       const initial = await fs.readFile(path.join(repoRoot, "docs", "overview.md"), "utf8");
       expect(initial).toContain("generated_at: '2024-01-02T03:04:05.000Z'");
 
       vi.setSystemTime(new Date("2024-05-06T07:08:09Z"));
-      const second = await generateDocs({ repoRoot, write: true });
+      const second = await generateDocs({ repoRoot, write: true, flags: DEFAULT_FEATURE_FLAGS });
       expect(second.outputs.every(output => output.changed === false)).toBe(true);
       const after = await fs.readFile(path.join(repoRoot, "docs", "overview.md"), "utf8");
       expect(after).toBe(initial);
@@ -191,7 +192,7 @@ describe("mode generator snapshots", () => {
     activeCatalogEntry = createCatalogEntry(activeBundle);
 
     vi.setSystemTime(new Date("2024-01-02T03:04:05Z"));
-    await generateDocs({ repoRoot, write: true });
+    await generateDocs({ repoRoot, write: true, flags: DEFAULT_FEATURE_FLAGS });
     const markdown = await fs.readFile(path.join(repoRoot, ...fixture.outputPath), "utf8");
     expect(markdown).toMatchSnapshot();
   });


### PR DESCRIPTION
## Summary
- add layered feature flag resolution and expose secure-mode guard rails across CLI entrypoints
- introduce a central compliance framework registry plus discovery/config commands
- surface experimental/GA state across TUI, provenance, manifest, doctor, docs, and CI guardrails

## Testing
- `pnpm -r test`
- `pnpm -r build` *(fails: docusaurus build reports a broken /docs/speckit-spec link)*

------
https://chatgpt.com/codex/tasks/task_e_68d47f4569808324b6f2abe1a0acd7fc