### PR TITLE
Fix CLI dev adapter resolution

### DIFF
--- a/packages/speckit-cli/src/index.ts
+++ b/packages/speckit-cli/src/index.ts
@@ -1,3 +1,5 @@
+import type { FrameworkMeta } from "./config/frameworkRegistry.js";
+
 export { useTemplateIntoDir } from "./services/template.js";
 export type { PostInitCommandEvent } from "./services/template.js";
 export {

--- a/packages/speckit-cli/src/services/mode.ts
+++ b/packages/speckit-cli/src/services/mode.ts
@@ -1,5 +1,7 @@
 import { resolvePreset } from "@speckit/presets";
 
+export { DEFAULT_GENERATION_MODE, parseGenerationMode } from "./generationMode.js";
+
 export function frameworksFromMode(mode: "classic" | "secure"): string[] {
   return resolvePreset(mode);
 }


### PR DESCRIPTION
## Summary
- re-export generation mode helpers from the CLI mode service so audit imports resolve at runtime
- ensure the CLI index pulls in framework metadata types before referencing them in downstream type exports

## Testing
- pnpm --filter @speckit/cli dev
- pnpm --filter @speckit/cli start -- template list
- pnpm --filter @speckit/cli build
- pnpm --filter @speckit/gen-tests test

------
https://chatgpt.com/codex/tasks/task_e_68d51deb1d608324b56fb10d272d52c7