### PR TITLE
Fix CLI binary bootstrap to eliminate pnpm install warnings

### DIFF
--- a/packages/speckit-cli/bin/run.mjs
+++ b/packages/speckit-cli/bin/run.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL, fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const distEntrypoint = path.resolve(__dirname, "../dist/cli.js");
+
+const run = async () => {
+  if (fs.existsSync(distEntrypoint)) {
+    await import(pathToFileURL(distEntrypoint).href);
+    return;
+  }
+
+  console.error(
+    "speckit CLI has not been built yet. Run `pnpm --filter @speckit/cli build` or `pnpm -r build` to generate dist files.",
+  );
+  process.exitCode = 1;
+  return;
+};
+
+run().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/packages/speckit-cli/package.json
+++ b/packages/speckit-cli/package.json
@@ -3,8 +3,8 @@
   "version": "0.1.0",
   "type": "module",
   "bin": {
-    "speckit": "dist/cli.js",
-    "spec": "dist/cli.js"
+    "speckit": "bin/run.mjs",
+    "spec": "bin/run.mjs"
   },
   "main": "dist/index.cjs",
   "module": "dist/index.js",

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -22,7 +22,10 @@
       "@speckit/tui": ["packages/speckit-tui/src/index.tsx"],
       "@speckit/cli": ["packages/speckit-cli/src/index.ts"],
       "@speckit/adapter-speckit-v1": ["packages/adapter-speckit-v1/src/index.ts"],
-      "@speckit/adapter-owasp-asvs-v4": ["packages/adapter-owasp-asvs-v4/src/index.ts"]
+      "@speckit/adapter-owasp-asvs-v4": ["packages/adapter-owasp-asvs-v4/src/index.ts"],
+      "@speckit/adapter-edu-us": ["packages/adapter-edu-us/src/index.ts"],
+      "@speckit/adapter-hipaa": ["packages/adapter-hipaa/src/index.ts"],
+      "@speckit/gen-tests": ["packages/speckit-gen-tests/src/index.ts"]
     }
   }
 }


### PR DESCRIPTION
## Summary
- point the speckit CLI package bin to a checked-in launcher so pnpm install no longer warns about missing dist binaries
- emit a helpful message when the CLI dist bundle has not been built yet and document how to build it
- add workspace path aliases for additional packages so TypeScript tooling can resolve their source during development

## Testing
- pnpm install
- pnpm --filter @speckit/cli... build
- pnpm --filter @speckit/cli start -- --help
- pnpm --filter @speckit/tui build
- pnpm --filter @speckit/tui start


------
https://chatgpt.com/codex/tasks/task_e_68d5211cecd88324898c83c0e65fb011