### PR TITLE
Ensure commit-msg hook upgrades Node runtime

### DIFF
--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,2 +1,39 @@
 #!/usr/bin/env sh
+set -eu
+
+# Keep this in sync with .husky/pre-commit so GUI git clients that ship
+# extremely old Node.js binaries (SourceTree, Tower, etc.) upgrade to a
+# modern runtime before invoking pnpm's Corepack shim.
+NODE_VERSION=0
+if command -v node >/dev/null 2>&1; then
+  NODE_VERSION=$(node -p "parseInt(process.versions.node.split('.')[0], 10)")
+fi
+
+if [ "$NODE_VERSION" -lt 18 ]; then
+  if [ -z "${NVM_DIR-}" ]; then
+    NVM_DIR="$HOME/.nvm"
+  fi
+  export NVM_DIR
+  if [ -s "$NVM_DIR/nvm.sh" ]; then
+    # shellcheck disable=SC1090
+    . "$NVM_DIR/nvm.sh"
+    if [ -f .nvmrc ]; then
+      nvm use >/dev/null
+    else
+      nvm use 18 >/dev/null || nvm install 18 >/dev/null
+    fi
+    NODE_VERSION=$(node -p "parseInt(process.versions.node.split('.')[0], 10)")
+  fi
+fi
+
+if [ "$NODE_VERSION" -lt 18 ]; then
+  echo "[husky] Node.js 18+ is required to lint commit messages." >&2
+  echo "[husky] Install a modern Node.js via https://nodejs.org/ or nvm." >&2
+  exit 1
+fi
+
+if command -v corepack >/dev/null 2>&1; then
+  corepack enable pnpm >/dev/null 2>&1 || true
+fi
+
 pnpm commitlint --edit "$1"


### PR DESCRIPTION
## Summary
- ensure the commit-msg husky hook matches the pre-commit guard so GUI Git clients upgrade to a modern Node.js runtime before running pnpm commitlint

## Testing
- pnpm --filter @speckit/gen-tests test *(fails: vitest missing without installing workspace dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68d529ef49248324b45b13f5acde238b