### PR TITLE
Fix CI pnpm setup and SBOM generation

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -26,6 +26,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 24
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.12.0
       - name: Install dependencies
         run: |
           corepack enable

--- a/.github/workflows/compliance-hipaa.yml
+++ b/.github/workflows/compliance-hipaa.yml
@@ -43,6 +43,11 @@ jobs:
         with:
           node-version: '24'
           cache: pnpm
+      - name: Setup pnpm
+        if: steps.filter.outputs.should_run == 'true'
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.12.0
       - name: Install dependencies
         if: steps.filter.outputs.should_run == 'true'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,11 @@ jobs:
         with:
           node-version: 24
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.12.0
+
       - name: Install dependencies
         run: |
           corepack enable

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -21,13 +21,18 @@ jobs:
         with:
           node-version: 24
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.12.0
+
       - name: Install dependencies
         run: |
           corepack enable
           pnpm install --frozen-lockfile=false
 
       - name: Generate CycloneDX SBOM
-        run: npx @cyclonedx/cyclonedx-node-npm --output-format JSON --output-file bom.json
+        run: npx @cyclonedx/cyclonedx-npm --output-format JSON --output-file bom.json
 
       - name: Upload SBOM artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/speckit-verify.yml
+++ b/.github/workflows/speckit-verify.yml
@@ -10,6 +10,10 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with: { node-version: '24', cache: 'pnpm' }
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 9.12.0
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
       - run: pnpm -w -r build


### PR DESCRIPTION
## Summary
- ensure pnpm/action-setup installs pnpm before workflows invoke it
- update the SBOM workflow to call the correct `@cyclonedx/cyclonedx-npm` CLI package

## Testing
- pnpm install --frozen-lockfile=false
- vitest run

------
https://chatgpt.com/codex/tasks/task_e_68d569d1bf648324a704a5e7173434c8