### PR TITLE
chore: enforce sanitized agent run forensics in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+# PR — SpecKit Run Forensics
+
+- [ ] Agent run logs uploaded as artifact `agent-run-logs` (sanitized)
+- [ ] `.speckit/summary.md` posted by CI
+- [ ] RTM managed table updated
+- [ ] No forbidden labels (read-before-write fail, git-state-drift)
+- [ ] Verification checklist included in plan or status
+
+**What changed & Why**
+-
+
+**Metrics snapshot (from CI)**
+
+
+ReqCoverage: <auto>
+BacktrackRatio: <auto>
+ToolPrecision@1: <auto>
+EditLocality: <auto>

--- a/.github/workflows/speckit-analyze-run.yml
+++ b/.github/workflows/speckit-analyze-run.yml
@@ -1,77 +1,49 @@
-name: speckit-analyze-run
-
+name: SpecKit — Analyze Agent Run
 on:
+  workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-
-permissions:
-  contents: write
-  pull-requests: write
-
+    types: [opened, synchronize, reopened]
 jobs:
   analyze:
-    name: Analyze agent run logs
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: read
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: 'pnpm'
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: "20" }
+      - run: corepack enable
+      - run: pnpm --version || npm i -g pnpm
+      - run: pnpm install --frozen-lockfile
 
       - name: Download agent run logs
-        id: download_logs
         uses: actions/download-artifact@v4
         with:
           name: agent-run-logs
-          path: agent-run-logs
-          if-no-files-found: ignore
+          path: ./agent-logs
 
-      - name: Detect log bundle
-        id: check_logs
+      - name: Unpack logs
         run: |
-          if compgen -G "agent-run-logs/**/*" > /dev/null; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "found=false" >> "$GITHUB_OUTPUT"
-          fi
+          mkdir -p runs_from_artifact
+          tar -xzf agent-logs/agent-run-logs.tar.gz -C runs_from_artifact
 
-      - name: Run analyzer
-        if: steps.check_logs.outputs.found == 'true'
-        run: pnpm speckit:analyze -- --raw-log "agent-run-logs/**/*"
+      - name: Analyze run logs
+        run: |
+          pnpm speckit:analyze -- --raw-log "runs_from_artifact/*" \
+            --write-rtm RTM.md --out .speckit
 
-      - name: Commit run artifacts
-        if: steps.check_logs.outputs.found == 'true'
+      - name: Commit RTM + artifacts (if changed)
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
-          commit_message: "chore: update speckit run artifacts"
-          branch: ${{ github.head_ref }}
+          commit_message: "chore(speckit): update RTM & .speckit artifacts"
           file_pattern: |
-            .speckit/*.json
-            .speckit/*.yaml
-            .speckit/*.md
-            .speckit/requirements.jsonl
             RTM.md
-            docs/internal/agents/coding-agent-brief.md
+            .speckit/**
 
-      - name: Post run summary comment
-        if: steps.check_logs.outputs.found == 'true'
+      - name: PR Comment — Run Forensics
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           recreate: true
           path: .speckit/summary.md
-
-      - name: No artifact notice
-        if: steps.check_logs.outputs.found != 'true'
-        run: echo "No agent-run-logs artifact found. Upload logs to enable run forensics."

--- a/.github/workflows/speckit-pr-gate.yml
+++ b/.github/workflows/speckit-pr-gate.yml
@@ -1,60 +1,33 @@
-name: speckit-pr-gate
-
+name: SpecKit — PR Gate
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
-
-permissions:
-  contents: read
-  pull-requests: read
-
+    types: [opened, synchronize, reopened]
 jobs:
   gate:
-    name: Enforce run forensics thresholds
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - name: Read metrics
+        id: metrics
+        run: |
+          if [ ! -f .speckit/metrics.json ]; then
+            echo '{}' > .speckit/metrics.json
+          fi
+          echo "METRICS=$(cat .speckit/metrics.json | tr -d '\n')" >> $GITHUB_OUTPUT
 
-      - name: Validate metrics
+      - name: Enforce thresholds
         run: |
           node <<'NODE'
-          const fs = require('fs');
-          const path = require('path');
-
-          const metricsPath = path.join(process.cwd(), '.speckit', 'metrics.json');
-          if (!fs.existsSync(metricsPath)) {
-            console.error('speckit-pr-gate: metrics.json not found. Run pnpm speckit:analyze and attach agent-run-logs.');
+          const m = JSON.parse(process.env.METRICS || '{}');
+          const cov = m.ReqCoverage ?? 0;
+          const tp1 = m.ToolPrecision1 ?? 0;
+          const back = m.BacktrackRatio ?? 1;
+          const failures = Array.isArray(m.FailureLabels) ? m.FailureLabels : [];
+          const bad = failures.includes('process.read-before-write-fail') || failures.includes('env.git-state-drift');
+          if (cov < 0.75 || tp1 < 0.65 || back > 0.35 || bad) {
+            console.error('PR gate failed', { cov, tp1, back, bad, failures });
             process.exit(1);
           }
-
-          const data = JSON.parse(fs.readFileSync(metricsPath, 'utf8'));
-          const metrics = data.metrics || {};
-          const labels = new Set(data.labels || []);
-
-          const failures = [];
-
-          if (typeof metrics.ReqCoverage === 'number' && metrics.ReqCoverage < 0.75) {
-            failures.push(`ReqCoverage ${metrics.ReqCoverage} < 0.75`);
-          }
-          if (typeof metrics.ToolPrecisionAt1 === 'number' && metrics.ToolPrecisionAt1 < 0.65) {
-            failures.push(`ToolPrecision@1 ${metrics.ToolPrecisionAt1} < 0.65`);
-          }
-          if (typeof metrics.BacktrackRatio === 'number' && metrics.BacktrackRatio > 0.35) {
-            failures.push(`BacktrackRatio ${metrics.BacktrackRatio} > 0.35`);
-          }
-
-          const forbidden = ['process.read-before-write-fail', 'env.git-state-drift'];
-          for (const label of forbidden) {
-            if (labels.has(label)) {
-              failures.push(`Forbidden label detected: ${label}`);
-            }
-          }
-
-          if (failures.length > 0) {
-            console.error('speckit-pr-gate failures:\n- ' + failures.join('\n- '));
-            process.exit(1);
-          }
-
-          console.log('speckit-pr-gate: thresholds satisfied.');
           NODE
+        env:
+          METRICS: ${{ steps.metrics.outputs.METRICS }}

--- a/.github/workflows/speckit-upload-logs.yml
+++ b/.github/workflows/speckit-upload-logs.yml
@@ -1,0 +1,44 @@
+name: SpecKit — Upload Agent Run Logs
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  upload-logs:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure run logs exist
+        run: |
+          mkdir -p runs || true
+          if [ -z "$(ls -A runs 2>/dev/null)" ]; then
+            echo "ERROR: No run logs found in ./runs"; exit 1;
+          fi
+
+      - name: Sanitize logs (redact secrets)
+        run: |
+          mkdir -p runs_sanitized
+          for f in runs/*; do
+            [ -f "$f" ] || continue
+            sed -E \
+              -e 's/(api[_-]?key|token|secret|password|authorization|bearer)[=: ]+[A-Za-z0-9._-]+/\1=REDACTED/gi' \
+              -e 's/(app-token|csrf|auth_id|cookie|set-cookie)[=: ]+[^ ,;]+/\1=REDACTED/gi' \
+              -e 's@https?://([^/]+):[^@]+@https://\1:REDACTED@g' \
+              "$f" > "runs_sanitized/$(basename "$f")"
+          done
+
+      - name: Compress logs
+        run: |
+          tar -czf agent-run-logs.tar.gz -C runs_sanitized .
+
+      - name: Upload agent run logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: agent-run-logs
+          path: agent-run-logs.tar.gz
+          if-no-files-found: error
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ docs/website/build
 
 # Speckit cache and generated previews
 .speckit/cache/
+
+# Local agent run logs (never commit raw logs)
+runs/
+runs/**/*.log

--- a/.speckit/metrics.json
+++ b/.speckit/metrics.json
@@ -1,6 +1,14 @@
 {
   "run_id": "test-run",
   "generated_at": "2025-09-26T22:10:48.440Z",
+  "ReqCoverage": 1,
+  "BacktrackRatio": 0,
+  "ToolPrecisionAt1": 1,
+  "ToolPrecision1": 1,
+  "EditLocality": 1,
+  "ReflectionDensity": 0,
+  "TTFPSeconds": null,
+  "FailureLabels": [],
   "metrics": {
     "ReqCoverage": 1,
     "BacktrackRatio": 0,

--- a/README.md
+++ b/README.md
@@ -119,6 +119,14 @@ We use **SemVer 0.x** during pre‑release. Any minor (`0.MINOR.PATCH`) **may** 
 
 ---
 
+## Run Forensics Quick Start
+
+- Place your agent's logs in `runs/` (local) or let the workflow upload them.
+- On PR, CI sanitizes, uploads, analyzes, posts summary, and gates merge.
+- Tune thresholds in `speckit.config.yaml`.
+
+---
+
 ## Contributing
 
 Before opening a PR:


### PR DESCRIPTION
## Summary
- add a dedicated workflow that sanitizes local run logs and uploads them as a pull request artifact
- update the analyzer, RTM updater, and workflows to consume the artifact, flatten metrics, and gate merges on coverage/precision thresholds
- document the run-forensics process, ignore raw logs, and require a run checklist in the PR template

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7149a1c8883248aa88bd760a43344