### PR TITLE
feat: add analyzer package and refactor CLI integration

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "node": ">=20"
   },
   "devDependencies": {
+    "@speckit/analyzer": "workspace:*",
     "@changesets/cli": "^2.27.9",
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.3.0",

--- a/packages/speckit-analyzer/package.json
+++ b/packages/speckit-analyzer/package.json
@@ -1,0 +1,37 @@
+{
+  "name": "@speckit/analyzer",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./adapters/node": {
+      "types": "./dist/adapters/node.d.ts",
+      "import": "./dist/adapters/node.mjs",
+      "require": "./dist/adapters/node.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup src/index.ts src/adapters/node.ts --format esm,cjs --dts --clean --target es2022",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@noble/hashes": "^1.4.0",
+    "strip-ansi": "^7.1.0",
+    "yaml": "^2.6.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.1",
+    "typescript": "^5.6.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/speckit-analyzer/src/adapters/node.ts
+++ b/packages/speckit-analyzer/src/adapters/node.ts
@@ -1,0 +1,45 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import type { FailureRule, RawLogSource } from "../types.js";
+import { parseFailureRules } from "../rules.js";
+
+export interface FileLogSourceOptions {
+  id?: string;
+  encoding?: BufferEncoding;
+  format?: RawLogSource["format"];
+}
+
+export async function createFileLogSource(
+  filePath: string,
+  options: FileLogSourceOptions = {}
+): Promise<RawLogSource> {
+  const raw = await fs.readFile(filePath, { encoding: options.encoding ?? "utf8" });
+  return {
+    id: options.id ?? filePath,
+    content: raw,
+    format: options.format,
+  };
+}
+
+export async function loadLogSourcesFromFiles(
+  paths: string[],
+  options: FileLogSourceOptions = {}
+): Promise<RawLogSource[]> {
+  return Promise.all(paths.map((filePath) => createFileLogSource(filePath, { ...options, id: options.id ?? filePath })));
+}
+
+export async function loadFailureRulesFromFs(
+  rootDir: string,
+  artifactDir?: string
+): Promise<FailureRule[]> {
+  const baseDir = artifactDir ?? path.join(rootDir, ".speckit");
+  const rulesPath = path.join(baseDir, "failure-rules.yaml");
+  try {
+    const raw = await fs.readFile(rulesPath, "utf8");
+    return parseFailureRules(raw);
+  } catch (error) {
+    console.warn(`[analyzer:node] Unable to load failure rules from ${rulesPath}: ${(error as Error).message}`);
+    return [];
+  }
+}

--- a/packages/speckit-analyzer/src/analyze.ts
+++ b/packages/speckit-analyzer/src/analyze.ts
@@ -1,0 +1,182 @@
+import {
+  type AnalyzeOptions,
+  type AnalyzerEvent,
+  type AnalyzerResult,
+  type EventsLogSource,
+  type LogSource,
+  type LogSourceInput,
+  type NormalizedLog,
+  type NormalizedLogSource,
+  type RawLogSource,
+} from "./types.js";
+import {
+  buildRunArtifact,
+  detectPrompt,
+  mergeNormalized,
+  normalizeLogContent,
+  normalizedFromEvents,
+} from "./normalize.js";
+import { deriveRequirements, attachEvidence } from "./requirements.js";
+import { computeMetrics } from "./metrics.js";
+import { applyFailureLabels, labelsToHints } from "./rules.js";
+
+function isPromiseLike<T>(value: unknown): value is Promise<T> {
+  return typeof value === "object" && value !== null && "then" in value && typeof (value as any).then === "function";
+}
+
+function isNormalizedLogSource(value: any): value is NormalizedLogSource {
+  return value && typeof value === "object" && "log" in value && Array.isArray((value as NormalizedLogSource).log.events);
+}
+
+function isEventsLogSource(value: any): value is EventsLogSource {
+  return value && typeof value === "object" && Array.isArray((value as EventsLogSource).events);
+}
+
+function isRawLogSource(value: any): value is RawLogSource {
+  return value && typeof value === "object" && typeof (value as RawLogSource).content === "string";
+}
+
+async function resolveInput(input: LogSourceInput): Promise<LogSource | string> {
+  if (isPromiseLike<LogSource | string>(input)) {
+    return resolveInput(await input);
+  }
+  return input;
+}
+
+interface NormalizedPart {
+  id?: string;
+  normalized: NormalizedLog;
+}
+
+async function normalizeSource(
+  source: LogSource | string,
+  index: number,
+  fallbackStart: Date
+): Promise<NormalizedPart> {
+  if (typeof source === "string") {
+    const sourceId = `source-${index + 1}`;
+    const normalized = normalizeLogContent(source, {
+      fallbackStart,
+      source: sourceId,
+    });
+    return { id: sourceId, normalized };
+  }
+  if (isNormalizedLogSource(source)) {
+    return { id: source.id, normalized: source.log };
+  }
+  if (isEventsLogSource(source)) {
+    return {
+      id: source.id,
+      normalized: normalizedFromEvents(source.events, source.promptCandidates ?? [], source.plainText),
+    };
+  }
+  if (isRawLogSource(source)) {
+    const normalized = normalizeLogContent(source.content, {
+      fallbackStart,
+      source: source.id,
+      format: source.format,
+    });
+    return { id: source.id ?? `source-${index + 1}`, normalized };
+  }
+  throw new Error("Unsupported log source provided to analyzer");
+}
+
+async function* iterateSources(
+  sources: AnalyzeOptions["sources"]
+): AsyncGenerator<LogSource | string, void, unknown> {
+  if ((sources as AsyncIterable<LogSourceInput>)[Symbol.asyncIterator]) {
+    for await (const entry of sources as AsyncIterable<LogSourceInput>) {
+      yield await resolveInput(entry);
+    }
+  } else {
+    for (const entry of sources as Iterable<LogSourceInput>) {
+      yield await resolveInput(entry);
+    }
+  }
+}
+
+function combineNormalized(parts: NormalizedPart[]): NormalizedLog {
+  if (parts.length === 0) {
+    return { events: [], promptCandidates: [], plainText: "" };
+  }
+  let aggregate = parts[0].normalized;
+  for (let i = 1; i < parts.length; i += 1) {
+    aggregate = mergeNormalized(aggregate, parts[i].normalized);
+  }
+  const annotatedPlain = parts
+    .map((part) => {
+      const header = part.id ? `# Source: ${part.id}\n` : "";
+      return `${header}${part.normalized.plainText}`.trim();
+    })
+    .filter((chunk) => chunk.length > 0)
+    .join("\n\n");
+  return {
+    events: aggregate.events,
+    promptCandidates: aggregate.promptCandidates,
+    plainText: annotatedPlain || aggregate.plainText,
+  };
+}
+
+export async function* analyzeStream(options: AnalyzeOptions): AsyncGenerator<AnalyzerEvent, AnalyzerResult, void> {
+  const now = options.now?.() ?? new Date();
+  const parts: NormalizedPart[] = [];
+  const sourceIds: string[] = [];
+  let index = 0;
+
+  for await (const source of iterateSources(options.sources)) {
+    const fallbackStart = new Date(now.getTime() + index * 60_000);
+    const part = await normalizeSource(source, index, fallbackStart);
+    parts.push(part);
+    sourceIds.push(part.id ?? `source-${index + 1}`);
+    yield { type: "normalized", normalized: part.normalized, source: part.id };
+    index += 1;
+  }
+
+  const normalized = combineNormalized(parts);
+  yield { type: "combined", normalized };
+
+  const run = buildRunArtifact(sourceIds, normalized, options.runId, options.metadata);
+  yield { type: "run", run };
+
+  const prompt = options.prompt ?? detectPrompt(normalized.promptCandidates, normalized.plainText);
+  yield { type: "prompt", prompt };
+
+  const requirements = attachEvidence(deriveRequirements(prompt), run.events);
+  yield { type: "requirements", requirements };
+
+  const metrics = computeMetrics(requirements, run.events);
+  yield { type: "metrics", metrics };
+
+  const rules = options.rules ?? [];
+  const labels = applyFailureLabels(rules, normalized.plainText, run.events);
+  if (requirements.some((req) => req.id === "REQ-000")) {
+    labels.add("prompt.missing");
+  }
+  const hints = labelsToHints(labels, rules);
+  yield { type: "labels", labels: Array.from(labels), hints };
+
+  const result: AnalyzerResult = {
+    run,
+    normalized,
+    prompt,
+    requirements,
+    metrics,
+    labels,
+    hints,
+  };
+  yield { type: "complete", result };
+  return result;
+}
+
+export async function analyze(options: AnalyzeOptions): Promise<AnalyzerResult> {
+  let final: AnalyzerResult | null = null;
+  for await (const event of analyzeStream(options)) {
+    if (event.type === "complete") {
+      final = event.result;
+    }
+  }
+  if (!final) {
+    throw new Error("Analyzer stream completed without producing a result");
+  }
+  return final;
+}

--- a/packages/speckit-analyzer/src/index.ts
+++ b/packages/speckit-analyzer/src/index.ts
@@ -1,0 +1,46 @@
+export type {
+  AnalyzeOptions,
+  AnalyzerEvent,
+  AnalyzerResult,
+  EventsLogSource,
+  FailureRule,
+  LogSource,
+  LogSourceInput,
+  Metrics,
+  NormalizedLog,
+  NormalizeOptions,
+  RequirementRecord,
+  RunArtifact,
+  RunEvent,
+  RunEventKind,
+} from "./types.js";
+
+export {
+  analyze,
+  analyzeStream,
+} from "./analyze.js";
+
+export {
+  buildRunArtifact,
+  detectPrompt,
+  mergeNormalized,
+  normalizeLogContent,
+  normalizedFromEvents,
+} from "./normalize.js";
+
+export {
+  deriveRequirements,
+  attachEvidence,
+  combineRequirements,
+  extractImperative,
+} from "./requirements.js";
+
+export { computeMetrics, summarizeMetrics } from "./metrics.js";
+
+export {
+  applyFailureLabels,
+  labelsToHints,
+  parseFailureRules,
+  FailureRulesSchema,
+  type FailureRulesConfig,
+} from "./rules.js";

--- a/packages/speckit-analyzer/src/metrics.ts
+++ b/packages/speckit-analyzer/src/metrics.ts
@@ -1,14 +1,4 @@
-import type { RunEvent } from "./normalize.js";
-import type { RequirementRecord } from "./requirements.js";
-
-export interface Metrics {
-  ReqCoverage: number;
-  BacktrackRatio: number;
-  ToolPrecisionAt1: number;
-  EditLocality: number;
-  ReflectionDensity: number;
-  TTFPSeconds: number | null;
-}
+import type { Metrics, RequirementRecord, RunEvent } from "./types.js";
 
 export function computeMetrics(requirements: RequirementRecord[], events: RunEvent[]): Metrics {
   const satisfied = requirements.filter(

--- a/packages/speckit-analyzer/src/requirements.ts
+++ b/packages/speckit-analyzer/src/requirements.ts
@@ -1,15 +1,4 @@
-import type { RunEvent } from "./normalize.js";
-
-export interface RequirementRecord {
-  id: string;
-  text: string;
-  source?: string;
-  category?: string | null;
-  constraints?: string[];
-  status: "unknown" | "satisfied" | "violated" | "in-progress";
-  evidence: string[];
-  notes?: string;
-}
+import type { RequirementRecord, RunEvent } from "./types.js";
 
 const imperativePatterns = [
   /^(must|should|ensure|create|add|update|implement|run|avoid|verify|write|check|document)\b/i,

--- a/packages/speckit-analyzer/src/types.ts
+++ b/packages/speckit-analyzer/src/types.ts
@@ -1,0 +1,124 @@
+export type RunEventKind =
+  | "plan"
+  | "search"
+  | "edit"
+  | "run"
+  | "eval"
+  | "reflect"
+  | "tool"
+  | "log"
+  | "summary"
+  | "error";
+
+export interface RunEvent {
+  id: string;
+  timestamp: string;
+  kind: RunEventKind | string;
+  subtype?: string | null;
+  role?: string | null;
+  input?: unknown;
+  output?: unknown;
+  error?: unknown;
+  files_changed?: string[];
+  meta?: Record<string, unknown>;
+}
+
+export interface NormalizedLog {
+  events: RunEvent[];
+  promptCandidates: string[];
+  plainText: string;
+}
+
+export interface NormalizeOptions {
+  fallbackStart?: Date;
+  source?: string;
+  format?: "auto" | "json" | "ndjson" | "text";
+}
+
+export interface RunArtifact {
+  runId: string;
+  sourceLogs: string[];
+  startedAt: string | null;
+  finishedAt: string | null;
+  events: RunEvent[];
+  metadata?: Record<string, unknown>;
+}
+
+export interface RequirementRecord {
+  id: string;
+  text: string;
+  source?: string;
+  category?: string | null;
+  constraints?: string[];
+  status: "unknown" | "satisfied" | "violated" | "in-progress";
+  evidence: string[];
+  notes?: string;
+}
+
+export interface Metrics {
+  ReqCoverage: number;
+  BacktrackRatio: number;
+  ToolPrecisionAt1: number;
+  EditLocality: number;
+  ReflectionDensity: number;
+  TTFPSeconds: number | null;
+}
+
+export interface FailureRule {
+  id: string;
+  label?: string;
+  description?: string;
+  patterns: string[];
+  remediation?: string;
+  hint?: string;
+}
+
+export interface RawLogSource {
+  id?: string;
+  content: string;
+  format?: NormalizeOptions["format"];
+}
+
+export interface NormalizedLogSource {
+  id?: string;
+  log: NormalizedLog;
+}
+
+export interface EventsLogSource {
+  id?: string;
+  events: RunEvent[];
+  promptCandidates?: string[];
+  plainText?: string;
+}
+
+export type LogSource = RawLogSource | NormalizedLogSource | EventsLogSource;
+export type LogSourceInput = LogSource | string | Promise<LogSource | string>;
+
+export interface AnalyzerResult {
+  run: RunArtifact;
+  normalized: NormalizedLog;
+  prompt: string;
+  requirements: RequirementRecord[];
+  metrics: Metrics;
+  labels: Set<string>;
+  hints: string[];
+}
+
+export type AnalyzerEvent =
+  | { type: "normalized"; normalized: NormalizedLog; source?: string }
+  | { type: "combined"; normalized: NormalizedLog }
+  | { type: "run"; run: RunArtifact }
+  | { type: "prompt"; prompt: string }
+  | { type: "requirements"; requirements: RequirementRecord[] }
+  | { type: "metrics"; metrics: Metrics }
+  | { type: "labels"; labels: string[]; hints: string[] }
+  | { type: "complete"; result: AnalyzerResult };
+
+export interface AnalyzeOptions {
+  sources: Iterable<LogSourceInput> | AsyncIterable<LogSourceInput>;
+  rules?: FailureRule[];
+  runId?: string;
+  prompt?: string;
+  metadata?: Record<string, unknown>;
+  now?: () => Date;
+}

--- a/packages/speckit-analyzer/test/analyze.test.ts
+++ b/packages/speckit-analyzer/test/analyze.test.ts
@@ -1,0 +1,85 @@
+import { fileURLToPath } from "node:url";
+import path from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+import {
+  analyze,
+  analyzeStream,
+  parseFailureRules,
+  type AnalyzerEvent,
+} from "../src/index.js";
+import { createFileLogSource } from "../src/adapters/node.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const fixturePath = path.join(__dirname, "fixtures", "successful-run.ndjson");
+const rulesYaml = `rules:\n  - id: doc.update\n    label: docs.update\n    patterns:\n      - "README"\n    remediation: "Confirm README changes"\n  - id: reflection\n    patterns:\n      - "Reflection"\n    hint: "Summarize reflection for UI"\n`;
+
+describe("analyzer integration", () => {
+  it("analyzes fixture logs and computes metrics", async () => {
+    const source = await createFileLogSource(fixturePath);
+    const result = await analyze({
+      sources: [source],
+      rules: parseFailureRules(rulesYaml),
+      runId: "run-fixture",
+    });
+
+    expect(result.run.runId).toBe("run-fixture");
+    expect(result.run.events).toHaveLength(6);
+    expect(result.run.sourceLogs).toEqual([fixturePath]);
+    expect(result.prompt).toContain("Ensure API logging is structured");
+
+    expect(result.requirements).toHaveLength(2);
+    expect(result.requirements.every((req) => req.status === "satisfied")).toBe(true);
+
+    expect(result.metrics.ReqCoverage).toBe(1);
+    expect(result.metrics.ToolPrecisionAt1).toBe(1);
+    expect(result.metrics.BacktrackRatio).toBe(0);
+    expect(result.metrics.EditLocality).toBeCloseTo(0.5, 2);
+    expect(result.metrics.ReflectionDensity).toBeCloseTo(0.5, 2);
+    expect(result.metrics.TTFPSeconds).toBe(300);
+
+    expect(Array.from(result.labels)).toEqual(["docs.update", "reflection"]);
+    expect(result.hints).toEqual([
+      "Confirm README changes",
+      "Summarize reflection for UI",
+    ]);
+  });
+
+  it("streams incremental analyzer events", async () => {
+    const source = await createFileLogSource(fixturePath);
+    const events: AnalyzerEvent["type"][] = [];
+    let streamedPrompt: string | null = null;
+
+    for await (const event of analyzeStream({ sources: [source], rules: parseFailureRules(rulesYaml) })) {
+      events.push(event.type);
+      if (event.type === "prompt") {
+        streamedPrompt = event.prompt;
+      }
+    }
+
+    expect(events).toEqual([
+      "normalized",
+      "combined",
+      "run",
+      "prompt",
+      "requirements",
+      "metrics",
+      "labels",
+      "complete",
+    ]);
+    expect(streamedPrompt).toContain("Ensure API logging is structured");
+  });
+
+  it("flags missing prompts and derives fallback requirements", async () => {
+    const rawLog = `2025-01-01T00:00:00Z LOG: Analyzer bootstrapped`;
+    const result = await analyze({ sources: [{ content: rawLog, id: "stdin" }] });
+
+    expect(result.requirements).toHaveLength(1);
+    expect(result.requirements[0].id).toBe("REQ-000");
+    expect(result.labels.has("prompt.missing")).toBe(true);
+    expect(result.prompt).toContain("Analyzer bootstrapped");
+  });
+});

--- a/packages/speckit-analyzer/test/fixtures/successful-run.ndjson
+++ b/packages/speckit-analyzer/test/fixtures/successful-run.ndjson
@@ -1,0 +1,6 @@
+{"timestamp":"2025-01-01T00:00:00Z","kind":"plan","prompt":"Ensure API logging is structured and includes trace ids.\nDocument the deployment process in README.","output":"Planning next actions"}
+{"timestamp":"2025-01-01T00:03:00Z","kind":"tool","subtype":"test","output":"npm test","error":null}
+{"timestamp":"2025-01-01T00:04:00Z","kind":"tool","subtype":"test","output":"Tests passed"}
+{"timestamp":"2025-01-01T00:05:00Z","kind":"edit","files_changed":["src/logger.ts"],"output":"Ensure API logging is structured and includes trace ids. Implementation completed successfully."}
+{"timestamp":"2025-01-01T00:07:00Z","kind":"edit","files_changed":["README.md"],"output":"Document the deployment process in README. Checklist completed and published."}
+{"timestamp":"2025-01-01T00:09:00Z","kind":"reflect","output":"Reflection: lessons learned and plan for next run"}

--- a/packages/speckit-analyzer/tsconfig.json
+++ b/packages/speckit-analyzer/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "module": "ESNext",
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*", "test/**/*"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/packages/speckit-analyzer/vitest.config.ts
+++ b/packages/speckit-analyzer/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      reporter: ["text", "lcov"],
+    },
+  },
+});

--- a/scripts/writers/artifacts.ts
+++ b/scripts/writers/artifacts.ts
@@ -1,9 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
-import type { RunArtifact } from "../analyzers/normalize.js";
-import type { RequirementRecord } from "../analyzers/requirements.js";
-import type { Metrics } from "../analyzers/score.js";
+import type { Metrics, RequirementRecord, RunArtifact } from "@speckit/analyzer";
 
 export interface MemoArtifact {
   generated_at: string;

--- a/scripts/writers/rtm.ts
+++ b/scripts/writers/rtm.ts
@@ -1,8 +1,7 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
-import type { RequirementRecord } from "../analyzers/requirements.js";
-import type { RunArtifact } from "../analyzers/normalize.js";
+import type { RequirementRecord, RunArtifact } from "@speckit/analyzer";
 
 const START_MARKER = "<!-- speckit:rtm:start -->";
 const END_MARKER = "<!-- speckit:rtm:end -->";

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -14,6 +14,8 @@
     ],
     "baseUrl": ".",
     "paths": {
+      "@speckit/analyzer": ["packages/speckit-analyzer/src/index.ts"],
+      "@speckit/analyzer/*": ["packages/speckit-analyzer/src/*"],
       "@speckit/engine": ["packages/speckit-engine/src/index.ts"],
       "@speckit/feature-flags": ["packages/speckit-feature-flags/src/index.ts"],
       "@speckit/framework-registry": ["packages/speckit-framework-registry/src/index.ts"],


### PR DESCRIPTION
## Summary
- introduce the @speckit/analyzer workspace package with shared normalization, requirement, metrics, and rules utilities plus analyze/analyzeStream entry points
- add a node adapter that reads log files and failure rules so other tooling can opt into the analyzer logic without filesystem code
- refactor the CLI coach/analyze flow and artifact writers to consume the new analyzer API and add vitest coverage exercising log fixtures

## Testing
- pnpm --filter @speckit/analyzer test
- pnpm --filter @speckit/analyzer build

------
https://chatgpt.com/codex/tasks/task_e_68d7ca2c213083249baae3dda7d4bada