### PR TITLE
ci: prepare pnpm deps for speckit gate

### DIFF
--- a/.github/workflows/speckit-pr-gate.yml
+++ b/.github/workflows/speckit-pr-gate.yml
@@ -16,6 +16,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: 'pnpm'
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
       - name: Validate metrics
         run: |
           node <<'NODE'


### PR DESCRIPTION
## Summary
- add Node.js and pnpm setup steps before the metrics validation gate
- enable pnpm caching on the gate job so installs reuse the store

## Testing
- node -e "require('yaml'); console.log('yaml ok')"


------
https://chatgpt.com/codex/tasks/task_e_68d7e1cbd5408324808fb0767b419e13