### PR TITLE
Add version metadata to memo and metrics artifacts

### DIFF
--- a/.speckit/memo.json
+++ b/.speckit/memo.json
@@ -1,1 +1,12 @@
-{}
+{
+  "version": 1,
+  "generated_at": "",
+  "generated_from": {
+    "run_id": "",
+    "sources": []
+  },
+  "lessons": [],
+  "guardrails": [],
+  "checklist": [],
+  "labels": []
+}

--- a/.speckit/metrics.json
+++ b/.speckit/metrics.json
@@ -1,1 +1,11 @@
-{}
+{
+  "version": 1,
+  "ReqCoverage": 0,
+  "ToolPrecisionAt1": 0,
+  "BacktrackRatio": 0,
+  "EditLocality": 0,
+  "ReflectionDensity": 0,
+  "TTFPSeconds": null,
+  "labels": [],
+  "sanitizer_hits": 0
+}

--- a/docs/internal/spec_kit_agent_run_forensics_framework_integration_guide.md
+++ b/docs/internal/spec_kit_agent_run_forensics_framework_integration_guide.md
@@ -132,6 +132,7 @@ Generated after analysis; consumed on the **next run**. Save as `.speckit/memo.j
 
 ```json
 {
+  "version": 1,
   "lessons": [
     {"if": "workspace=pnpm", "then": "use pnpm not npm for install/test"},
     {"if": "jest not found", "then": "install deps, then run pnpm test -w"},
@@ -205,7 +206,7 @@ checks:
 1) **Ingest & Normalize:** parse raw logs → `Run.json`.
 2) **Extract Requirements:** from prompt → `requirements.jsonl`.
 3) **Align & Score:** coverage, metrics, failure labels → `.speckit/metrics.json`.
-4) **Artifacts:** write `memo.json`, `verification.yaml`, update `RTM.md` block.
+4) **Artifacts:** write versioned `memo.json`, `verification.yaml`, update `RTM.md` block.
 5) **Publish:** attach artifacts to PR comment & persist in repo/CI artifact.
 
 ---
@@ -254,7 +255,7 @@ Track:
   failure-rules.yaml
   memo.json                 # generated per run
   verification.yaml         # generated per run
-  metrics.json              # generated per run
+  metrics.json              # generated per run (versioned)
   run-schema/
     run.schema.json
     requirement.schema.json
@@ -374,7 +375,7 @@ jobs:
       - name: Read metrics
         id: metrics
         run: |
-          cat .speckit/metrics.json || echo '{"ReqCoverage":0}' > .speckit/metrics.json
+          cat .speckit/metrics.json || echo '{"version":1,"ReqCoverage":0}' > .speckit/metrics.json
           echo "METRICS=$(cat .speckit/metrics.json | tr -d '\n')" >> $GITHUB_OUTPUT
 
       - name: Enforce thresholds

--- a/docs/internal/spec_kit_coding_agent_prompt_to_integrate_run_forensics.md
+++ b/docs/internal/spec_kit_coding_agent_prompt_to_integrate_run_forensics.md
@@ -72,9 +72,9 @@ speckit.config.yaml                  # new config (repo root)
 - **Score:** compute metrics (ReqCoverage, BacktrackRatio, ToolPrecision@1, EditLocality, ReflectionDensity, TTFP).
 - **Label Failures:** apply regex rules → labels per episode.
 - **Artifacts:**
-  - Write `.speckit/memo.json` (lessons, guardrails, checklist, generated_from.run_id).
+  - Write `.speckit/memo.json` (version, lessons, guardrails, checklist, generated_from.run_id).
   - Write `.speckit/verification.yaml` (per‑requirement checks, at least stubs if unknown).
-  - Write `.speckit/metrics.json` and `.speckit/summary.md` (short PR‑comment report).
+  - Write `.speckit/metrics.json` (versioned snapshot) and `.speckit/summary.md` (short PR‑comment report).
 - **RTM update:** call `scripts/speckit-update-rtm.ts` to refresh the managed table.
 
 ### T3 — RTM updater (`scripts/speckit-update-rtm.ts`)

--- a/docs/speckit-run-coach.md
+++ b/docs/speckit-run-coach.md
@@ -56,9 +56,9 @@ pnpm speckit:inject                                      # Refresh prompt guardr
 
 Each coached run yields:
 
-- `.speckit/memo.json` — lessons, guardrails, and checklist items keyed to the run ID.
+- `.speckit/memo.json` — versioned lessons, guardrails, and checklist items keyed to the run ID.
 - `.speckit/verification.yaml` — CoVe verification stubs per requirement.
-- `.speckit/metrics.json` — metric snapshot and failure labels.
+- `.speckit/metrics.json` — versioned metric snapshot and failure labels.
 - `.speckit/summary.md` — summary used for PR comments.
 - `RTM.md` — updated Run Traceability Matrix between managed markers.
 

--- a/docs/speckit-run-forensics.md
+++ b/docs/speckit-run-forensics.md
@@ -6,7 +6,7 @@ The run forensics and self-healing loop connects raw agent logs → normalized r
 
 1. **Collect logs.** Record each agent execution (planner, executor, tools) and save them as text, JSON, or NDJSON.
 2. **Analyze.** Run `pnpm speckit:analyze -- --raw-log <glob>` to normalize the logs into `.speckit/Run.json`, extract prompt requirements into `.speckit/requirements.jsonl`, and score run metrics. The normalized `Run.json` includes a `schema` version (currently `1`) so downstream tooling can validate compatibility.
-3. **Update artifacts.** The analyzer emits `.speckit/memo.json`, `.speckit/verification.yaml`, `.speckit/metrics.json`, and `.speckit/summary.md`, then refreshes the RTM between `<!-- speckit:rtm:* -->` markers.
+3. **Update artifacts.** The analyzer emits versioned `.speckit/memo.json`, `.speckit/verification.yaml`, `.speckit/metrics.json`, and `.speckit/summary.md`, then refreshes the RTM between `<!-- speckit:rtm:* -->` markers.
 4. **Inject guardrails.** Run `pnpm speckit:inject` to merge the memo guardrails + verification checklist into `docs/internal/agents/coding-agent-brief.md` so the next run inherits lessons learned.
 5. **Gate in CI.** The `speckit-analyze-run` workflow fetches the `agent-run-logs` artifact on each PR, runs the analyzer, commits refreshed artifacts, and posts the summary. `speckit-pr-gate` blocks merges when metrics fall below thresholds or forbidden failure labels appear.
 
@@ -32,7 +32,7 @@ Forbidden labels enforced in CI: `process.read-before-write-fail`, `env.git-stat
 
 ## Local verification checklist
 
-1. Run `pnpm speckit:analyze -- --raw-log sample-logs/*.log` and confirm `.speckit/memo.json` includes `generated_from.run_id`.
+1. Run `pnpm speckit:analyze -- --raw-log sample-logs/*.log` and confirm `.speckit/memo.json` includes `version` and `generated_from.run_id`.
 2. Ensure `RTM.md` shows the managed table between `<!-- speckit:rtm:start -->` and `<!-- speckit:rtm:end -->`.
 3. Run `pnpm speckit:inject` and verify the coding agent brief now contains the latest memo guardrails + verification checklist.
 4. Commit refreshed artifacts before opening a PR so CI gates only enforce deltas from the latest run.

--- a/packages/speckit-analyzer/src/index.ts
+++ b/packages/speckit-analyzer/src/index.ts
@@ -1,4 +1,4 @@
-export { RUN_ARTIFACT_SCHEMA_VERSION } from "./types.js";
+export { RUN_ARTIFACT_SCHEMA_VERSION, MEMO_ARTIFACT_VERSION, METRICS_ARTIFACT_VERSION } from "./types.js";
 
 export type {
   AnalyzeOptions,

--- a/packages/speckit-analyzer/src/types.ts
+++ b/packages/speckit-analyzer/src/types.ts
@@ -36,6 +36,8 @@ export interface NormalizeOptions {
 }
 
 export const RUN_ARTIFACT_SCHEMA_VERSION = 1 as const;
+export const MEMO_ARTIFACT_VERSION = 1 as const;
+export const METRICS_ARTIFACT_VERSION = 1 as const;
 
 export interface RunArtifact {
   schema: number;

--- a/packages/speckit-analyzer/test/artifacts.test.ts
+++ b/packages/speckit-analyzer/test/artifacts.test.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import { describe, expect, it } from "vitest";
 
 import type { Metrics, RequirementRecord, RunArtifact } from "../src/types.js";
-import { RUN_ARTIFACT_SCHEMA_VERSION } from "../src/types.js";
+import {
+  MEMO_ARTIFACT_VERSION,
+  METRICS_ARTIFACT_VERSION,
+  RUN_ARTIFACT_SCHEMA_VERSION,
+} from "../src/types.js";
 
 describe("artifact writer", () => {
   it("writes Run.json with the schema version", async () => {
@@ -44,5 +48,13 @@ describe("artifact writer", () => {
 
     expect(parsed.schema).toBe(RUN_ARTIFACT_SCHEMA_VERSION);
     expect(parsed.run_id).toBe(run.runId);
+
+    const memoRaw = await readFile(path.join(outDir, "memo.json"), "utf8");
+    const memo = JSON.parse(memoRaw);
+    expect(memo.version).toBe(MEMO_ARTIFACT_VERSION);
+
+    const metricsRaw = await readFile(path.join(outDir, "metrics.json"), "utf8");
+    const metricsArtifact = JSON.parse(metricsRaw);
+    expect(metricsArtifact.version).toBe(METRICS_ARTIFACT_VERSION);
   });
 });

--- a/scripts/speckit-analyze-run.ts
+++ b/scripts/speckit-analyze-run.ts
@@ -6,7 +6,11 @@ import stripAnsi from "strip-ansi";
 import YAML from "yaml";
 import { z } from "zod";
 
-import { RUN_ARTIFACT_SCHEMA_VERSION } from "@speckit/analyzer";
+import {
+  MEMO_ARTIFACT_VERSION,
+  METRICS_ARTIFACT_VERSION,
+  RUN_ARTIFACT_SCHEMA_VERSION,
+} from "@speckit/analyzer";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -70,6 +74,7 @@ interface Metrics {
 }
 
 interface MemoArtifact {
+  version: number;
   generated_at: string;
   generated_from: {
     run_id: string;
@@ -470,6 +475,7 @@ function buildMemo(runId: string, sources: string[], requirements: RequirementRe
   });
 
   return {
+    version: MEMO_ARTIFACT_VERSION,
     generated_at: generatedAt,
     generated_from: {
       run_id: runId,
@@ -579,6 +585,7 @@ async function main(): Promise<void> {
   await writeJson(path.join(ARTIFACT_DIR, "Run.json"), runArtifact);
   await writeJsonl(path.join(ARTIFACT_DIR, "requirements.jsonl"), requirements);
   await writeJson(path.join(ARTIFACT_DIR, "metrics.json"), {
+    version: METRICS_ARTIFACT_VERSION,
     run_id: runArtifact.run_id,
     generated_at: new Date().toISOString(),
     metrics,

--- a/scripts/speckit-inject-artifacts.ts
+++ b/scripts/speckit-inject-artifacts.ts
@@ -16,6 +16,7 @@ const VERIFICATION_START = "<!-- speckit:verification:start -->";
 const VERIFICATION_END = "<!-- speckit:verification:end -->";
 
 interface MemoArtifact {
+  version?: number;
   generated_at?: string;
   generated_from?: {
     run_id?: string;

--- a/scripts/writers/artifacts.ts
+++ b/scripts/writers/artifacts.ts
@@ -1,11 +1,18 @@
 import { promises as fs } from "node:fs";
 import path from "node:path";
 import YAML from "yaml";
-import type { Metrics, RequirementRecord, RunArtifact } from "@speckit/analyzer";
+import {
+  MEMO_ARTIFACT_VERSION,
+  METRICS_ARTIFACT_VERSION,
+  type Metrics,
+  type RequirementRecord,
+  type RunArtifact,
+} from "@speckit/analyzer";
 
 const RUN_ARTIFACT_SCHEMA_FALLBACK = 1;
 
 export interface MemoArtifact {
+  version: number;
   generated_at: string;
   generated_from: {
     run_id: string;
@@ -64,6 +71,7 @@ function buildMemo(options: WriteArtifactsOptions): MemoArtifact {
     .map((req) => `Prevent regression on ${req.id}: ${req.text}`);
   const checklist = requirements.map((req) => `${req.id}: ${req.text}`);
   return {
+    version: MEMO_ARTIFACT_VERSION,
     generated_at: generatedAt,
     generated_from: {
       run_id: run.runId,
@@ -138,10 +146,13 @@ export async function writeArtifacts(options: WriteArtifactsOptions): Promise<Wr
   await writeJson(memoPath, memo);
   await fs.writeFile(verificationPath, YAML.stringify(verification), "utf8");
   await writeJson(metricsPath, {
+    version: METRICS_ARTIFACT_VERSION,
     ReqCoverage: options.metrics.ReqCoverage ?? 0,
     ToolPrecisionAt1: options.metrics.ToolPrecisionAt1 ?? 0,
     BacktrackRatio: options.metrics.BacktrackRatio ?? 0,
     EditLocality: options.metrics.EditLocality ?? 0,
+    ReflectionDensity: options.metrics.ReflectionDensity ?? 0,
+    TTFPSeconds: options.metrics.TTFPSeconds ?? null,
     labels: Array.from(options.labels),
     sanitizer_hits: options.sanitizerHits ?? 0,
   });


### PR DESCRIPTION
## Summary
- add shared memo and metrics artifact version constants and propagate them through the artifact writers
- include version fields in emitted memo and metrics payloads plus adjust dependent scripts, tests, and sample artifacts
- refresh documentation to describe the versioned schemas and update snippets accordingly

## Testing
- pnpm --filter @speckit/analyzer test *(fails: vitest missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7e1d6f9788324837baed99af2eb7a