### PR TITLE
Add experiment manifest and deterministic bucket wiring

### DIFF
--- a/.speckit/Run.json
+++ b/.speckit/Run.json
@@ -60,5 +60,19 @@
       "kind": "log",
       "output": ""
     }
-  ]
+  ],
+  "metadata": {
+    "experiments": [
+      {
+        "key": "memo_tone",
+        "description": "Compare memo guardrail tone between baseline and focused variants.",
+        "variant": "focused",
+        "variant_description": "Focused memo copy highlighting urgency for violations.",
+        "bucket": 421,
+        "metadata": {
+          "memo_tone": "focused"
+        }
+      }
+    ]
+  }
 }

--- a/.speckit/memo.json
+++ b/.speckit/memo.json
@@ -8,5 +8,17 @@
   "lessons": [],
   "guardrails": [],
   "checklist": [],
-  "labels": []
+  "labels": [],
+  "experiments": [
+    {
+      "key": "memo_tone",
+      "variant": "focused",
+      "bucket": 421,
+      "description": "Compare memo guardrail tone between baseline and focused variants.",
+      "variant_description": "Focused memo copy highlighting urgency for violations.",
+      "metadata": {
+        "memo_tone": "focused"
+      }
+    }
+  ]
 }

--- a/.speckit/metrics.json
+++ b/.speckit/metrics.json
@@ -7,5 +7,17 @@
   "ReflectionDensity": 0,
   "TTFPSeconds": null,
   "labels": [],
-  "sanitizer_hits": 0
+  "sanitizer_hits": 0,
+  "experiments": [
+    {
+      "key": "memo_tone",
+      "description": "Compare memo guardrail tone between baseline and focused variants.",
+      "variant": "focused",
+      "variant_description": "Focused memo copy highlighting urgency for violations.",
+      "bucket": 421,
+      "metadata": {
+        "memo_tone": "focused"
+      }
+    }
+  ]
 }

--- a/.speckit/summary.md
+++ b/.speckit/summary.md
@@ -4,6 +4,9 @@
 - Source logs: sample-logs/run.log
 - Events analyzed: 9
 
+## Experiments
+- memo_tone: focused (bucket 421) — Focused memo copy highlighting urgency for violations. — memo_tone: focused
+
 ## Metrics
 | Metric | Value |
 |--------|-------|

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ pnpm speckit:coach -- --log runs/sample.ndjson --watch
 
 4. **Open or sync a PR.** CI uploads sanitized logs (`speckit-upload-logs`), analyzes them (`speckit-analyze-run`), commits refreshed artifacts/RTM, posts `.speckit/summary.md` as a sticky comment, and only gates on critical labels (e.g., `process.read-before-write-fail`, `env.git-state-drift`).
 
+### Inner-loop experiments
+
+- Declare weighted variants in `speckit.experiments.yaml` (schema v1). Each experiment needs a unique `key`, optional `description`, and one or more `variants` with `weight` + free-form `metadata` used by downstream tooling.
+- The CLI seeds assignments with the final `run_id`, ensuring a replay of the same run sticks to the same variant/bucket. Buckets default to `0-999`; adjust `bucket_count` to widen/narrow ranges.
+- Active assignments flow through analyzer metadata, `.speckit/memo.json`, `.speckit/summary.md`, and `.speckit/metrics.json` so you can group metrics or PR comments by experiment.
+- Disable an experiment with `enabled: false` or tweak weights to rebalance live traffic. Commit the manifest so CI and local runs stay aligned.
+
 ---
 
 ## Key capabilities

--- a/docs/speckit-run-coach.md
+++ b/docs/speckit-run-coach.md
@@ -52,6 +52,13 @@ pnpm speckit:inject                                      # Refresh prompt guardr
 | **ReflectionDensity** | Share of reasoning events that include reflection. |
 | **TTFP** | Time-to-first-patch in seconds (when edits begin). |
 
+## Experiment buckets
+
+- Configure deterministic experiments in `speckit.experiments.yaml` (schema version `1`). Each entry defines a `key`, optional `description`, and weighted `variants` with custom metadata (e.g., `{ memo_tone: focused }`).
+- The CLI seeds assignments using the resolved `run_id`, so a replay of the same log sticks to the same variant and bucket. Buckets default to `0–999`; change `bucket_count` per experiment to fan out further.
+- `scripts/config/experiments.ts` loads the manifest, selects a variant via SHA-256 hashing, and threads the assignment through analyzer metadata.
+- Active variants appear in `.speckit/memo.json`, `.speckit/summary.md`, and `.speckit/metrics.json` for downstream dashboards and PR comments. Disable an experiment by flipping `enabled: false`.
+
 ## Self-healing artifacts
 
 Each coached run yields:

--- a/scripts/config/experiments.ts
+++ b/scripts/config/experiments.ts
@@ -1,0 +1,123 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import crypto from "node:crypto";
+import YAML from "yaml";
+import { z } from "zod";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, "..", "..");
+
+const VariantSchema = z
+  .object({
+    key: z.string(),
+    description: z.string().optional(),
+    weight: z.number().positive().default(1),
+    metadata: z.record(z.any()).default({}),
+  })
+  .strict();
+
+const ExperimentSchema = z
+  .object({
+    key: z.string(),
+    description: z.string().optional(),
+    enabled: z.boolean().default(true),
+    bucket_count: z.number().int().positive().max(10_000).default(1_000),
+    variants: z.array(VariantSchema).min(1),
+  })
+  .strict();
+
+const ExperimentsFileSchema = z
+  .object({
+    version: z.literal(1).default(1),
+    experiments: z.array(ExperimentSchema).default([]),
+  })
+  .strict();
+
+export type ExperimentsConfig = z.infer<typeof ExperimentsFileSchema>;
+export type ExperimentDefinition = z.infer<typeof ExperimentSchema>;
+export type ExperimentVariant = z.infer<typeof VariantSchema>;
+
+export interface ExperimentAssignment {
+  key: string;
+  description?: string;
+  variantKey: string;
+  variantDescription?: string;
+  bucket: number;
+  weight: number;
+  metadata: Record<string, unknown>;
+}
+
+export interface LoadExperimentAssignmentsOptions {
+  rootDir?: string;
+  seed: string;
+}
+
+function hashToUnitInterval(input: string): number {
+  const hash = crypto.createHash("sha256").update(input).digest();
+  const sample = hash.readUIntBE(0, 6);
+  const max = 0xffffffffffff;
+  return sample / max;
+}
+
+async function readConfig(rootDir: string): Promise<ExperimentsConfig> {
+  const configPath = path.join(rootDir, "speckit.experiments.yaml");
+  try {
+    const raw = await fs.readFile(configPath, "utf8");
+    const parsed = YAML.parse(raw) ?? {};
+    return ExperimentsFileSchema.parse(parsed);
+  } catch (error: unknown) {
+    if ((error as NodeJS.ErrnoException)?.code === "ENOENT") {
+      return { version: 1, experiments: [] };
+    }
+    throw new Error(`Failed to read speckit.experiments.yaml: ${(error as Error).message}`);
+  }
+}
+
+function pickVariant(experiment: ExperimentDefinition, seed: string): ExperimentVariant {
+  const totalWeight = experiment.variants.reduce((sum, variant) => sum + variant.weight, 0);
+  const normalizedTotal = totalWeight > 0 ? totalWeight : experiment.variants.length;
+  const unit = hashToUnitInterval(`${seed}:${experiment.key}`);
+  let cumulative = 0;
+  for (const variant of experiment.variants) {
+    const weight = variant.weight > 0 ? variant.weight : normalizedTotal / experiment.variants.length;
+    cumulative += weight / normalizedTotal;
+    if (unit <= cumulative) {
+      return variant;
+    }
+  }
+  return experiment.variants[experiment.variants.length - 1];
+}
+
+export async function loadExperimentAssignments(
+  options: LoadExperimentAssignmentsOptions
+): Promise<ExperimentAssignment[]> {
+  const rootDir = options.rootDir ?? ROOT;
+  const config = await readConfig(rootDir);
+  if (!config.experiments || config.experiments.length === 0) {
+    return [];
+  }
+  const seed = options.seed;
+  return config.experiments
+    .filter((experiment) => experiment.enabled)
+    .map((experiment) => {
+      const variant = pickVariant(experiment, seed);
+      const bucketCount = experiment.bucket_count ?? 1_000;
+      const unit = hashToUnitInterval(`${seed}:${experiment.key}:bucket`);
+      const bucket = Math.min(bucketCount - 1, Math.floor(unit * bucketCount));
+      return {
+        key: experiment.key,
+        description: experiment.description,
+        variantKey: variant.key,
+        variantDescription: variant.description,
+        bucket,
+        weight: variant.weight,
+        metadata: variant.metadata ?? {},
+      } satisfies ExperimentAssignment;
+    });
+}
+
+export async function loadExperimentsConfig(rootDir = ROOT): Promise<ExperimentsConfig> {
+  return readConfig(rootDir);
+}

--- a/scripts/writers/artifacts.ts
+++ b/scripts/writers/artifacts.ts
@@ -8,6 +8,7 @@ import {
   type RequirementRecord,
   type RunArtifact,
 } from "@speckit/analyzer";
+import type { ExperimentAssignment } from "../config/experiments.js";
 
 const RUN_ARTIFACT_SCHEMA_FALLBACK = 1;
 
@@ -22,6 +23,16 @@ export interface MemoArtifact {
   guardrails: string[];
   checklist: string[];
   labels: string[];
+  experiments: ExperimentMemoEntry[];
+}
+
+export interface ExperimentMemoEntry {
+  key: string;
+  variant: string;
+  bucket: number;
+  description?: string;
+  variant_description?: string;
+  metadata: Record<string, unknown>;
 }
 
 export interface VerificationRequirementEntry {
@@ -46,6 +57,7 @@ export interface WriteArtifactsOptions {
   metrics: Metrics;
   labels: Set<string>;
   sanitizerHits?: number;
+  experiments?: ExperimentAssignment[];
 }
 
 export interface WrittenArtifacts {
@@ -58,7 +70,7 @@ export interface WrittenArtifacts {
 }
 
 function buildMemo(options: WriteArtifactsOptions): MemoArtifact {
-  const { run, requirements, labels } = options;
+  const { run, requirements, labels, experiments = [] } = options;
   const generatedAt = new Date().toISOString();
   const lessons: string[] = [];
   if (labels.size > 0) {
@@ -81,6 +93,14 @@ function buildMemo(options: WriteArtifactsOptions): MemoArtifact {
     guardrails,
     checklist,
     labels: Array.from(labels),
+    experiments: experiments.map((experiment) => ({
+      key: experiment.key,
+      description: experiment.description,
+      variant: experiment.variantKey,
+      variant_description: experiment.variantDescription,
+      bucket: experiment.bucket,
+      metadata: experiment.metadata,
+    })),
   };
 }
 
@@ -99,15 +119,30 @@ function buildVerification(requirements: RequirementRecord[]): VerificationArtif
 }
 
 function buildSummary(options: WriteArtifactsOptions, memo: MemoArtifact): string {
-  const { run, metrics, requirements, labels } = options;
+  const { run, metrics, requirements, labels, experiments = [] } = options;
   const metricRows = Object.entries(metrics)
     .map(([key, value]) => `| ${key} | ${value ?? "—"} |`)
     .join("\n");
   const labelList = memo.labels.length > 0 ? memo.labels.map((label) => `- ${label}`).join("\n") : "- None";
   const requirementRows = requirements.map((req) => `- ${req.id} (${req.status}): ${req.text}`).join("\n");
+  const experimentLines =
+    experiments.length > 0
+      ? experiments
+          .map((experiment) => {
+            const description = experiment.variantDescription ?? experiment.description;
+            const metadataEntries = Object.entries(experiment.metadata ?? {});
+            const metadataText =
+              metadataEntries.length > 0
+                ? ` — ${metadataEntries.map(([key, value]) => `${key}: ${String(value)}`).join(", ")}`
+                : "";
+            const descriptionText = description ? ` — ${description}` : "";
+            return `- ${experiment.key}: ${experiment.variantKey} (bucket ${experiment.bucket})${descriptionText}${metadataText}`;
+          })
+          .join("\n")
+      : "- None";
   return `# SpecKit Run Forensics\n\n- Run ID: ${run.runId}\n- Source logs: ${run.sourceLogs
     .map((file) => path.relative(options.rootDir, file))
-    .join(", ")}\n- Events analyzed: ${run.events.length}\n\n## Metrics\n| Metric | Value |\n|--------|-------|\n${metricRows}\n\n## Labels\n${labelList}\n\n## Requirements\n${requirementRows}`;
+    .join(", ")}\n- Events analyzed: ${run.events.length}\n\n## Experiments\n${experimentLines}\n\n## Metrics\n| Metric | Value |\n|--------|-------|\n${metricRows}\n\n## Labels\n${labelList}\n\n## Requirements\n${requirementRows}`;
 }
 
 async function writeJson(filePath: string, data: unknown): Promise<void> {
@@ -141,6 +176,7 @@ export async function writeArtifacts(options: WriteArtifactsOptions): Promise<Wr
     started_at: options.run.startedAt,
     finished_at: options.run.finishedAt,
     events: options.run.events,
+    metadata: options.run.metadata ?? undefined,
   });
   await writeJsonl(requirementsPath, options.requirements);
   await writeJson(memoPath, memo);
@@ -155,6 +191,14 @@ export async function writeArtifacts(options: WriteArtifactsOptions): Promise<Wr
     TTFPSeconds: options.metrics.TTFPSeconds ?? null,
     labels: Array.from(options.labels),
     sanitizer_hits: options.sanitizerHits ?? 0,
+    experiments: (options.experiments ?? []).map((experiment) => ({
+      key: experiment.key,
+      description: experiment.description,
+      variant: experiment.variantKey,
+      variant_description: experiment.variantDescription,
+      bucket: experiment.bucket,
+      metadata: experiment.metadata,
+    })),
   });
   await fs.writeFile(summaryPath, summary + "\n", "utf8");
 

--- a/speckit.experiments.yaml
+++ b/speckit.experiments.yaml
@@ -1,0 +1,22 @@
+# SpecKit experiment manifest (v1)
+#
+# Each experiment declares a stable key, optional description, and weighted variants.
+# Variants are assigned deterministically per run using the run ID as a seed so
+# that the same log replay always resolves to the same bucket.
+version: 1
+experiments:
+  - key: memo_tone
+    description: Compare memo guardrail tone between baseline and focused variants.
+    enabled: true
+    bucket_count: 1000
+    variants:
+      - key: control
+        description: Baseline memo copy emphasizing steady hygiene.
+        weight: 1
+        metadata:
+          memo_tone: baseline
+      - key: focused
+        description: Focused memo copy highlighting urgency for violations.
+        weight: 1
+        metadata:
+          memo_tone: focused


### PR DESCRIPTION
## Summary
- add a versioned `speckit.experiments.yaml` manifest and a loader that deterministically assigns variants using the run id as a seed
- propagate the assigned experiment metadata through the CLI analyzer run, memo generation, and artifact writers
- surface the active variants in `.speckit` artifacts and document the experiment workflow for contributors

## Testing
- pnpm --filter @speckit/cli build *(fails: tsup not found in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d7fa59eedc8324ac3994009d729864