### PR TITLE
feat: add analyzer trends dashboard

### DIFF
--- a/.github/workflows/speckit-analyze-run.yml
+++ b/.github/workflows/speckit-analyze-run.yml
@@ -85,6 +85,10 @@ jobs:
           }
           NODE
 
+      - name: Update agent trends dashboard
+        if: steps.check_logs.outputs.found == 'true'
+        run: pnpm tsx scripts/analytics/trends.ts
+
       - name: Commit run artifacts
         if: steps.check_logs.outputs.found == 'true'
         uses: stefanzweifel/git-auto-commit-action@v5
@@ -96,6 +100,7 @@ jobs:
             .speckit/*.yaml
             .speckit/*.md
             .speckit/requirements.jsonl
+            docs/agent-trends.md
             RTM.md
             docs/internal/agents/coding-agent-brief.md
 

--- a/docs/agent-trends.md
+++ b/docs/agent-trends.md
@@ -1,0 +1,5 @@
+# Agent Label Trends
+
+Generated on 2025-09-27T15:37:03.117Z.
+
+No historical label data was found in `.speckit/metrics.json` or `requirements.jsonl`. Upload analyzer artifacts to begin tracking trends.

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "speckit:coach": "tsx scripts/cli.ts run --coach --watch",
     "speckit:doctor": "tsx scripts/cli.ts doctor",
     "speckit:analyze": "tsx scripts/cli.ts analyze",
-    "speckit:inject": "tsx scripts/cli.ts inject"
+    "speckit:inject": "tsx scripts/cli.ts inject",
+    "speckit:trends": "tsx scripts/analytics/trends.ts"
   },
   "keywords": [
     "spec-driven-development",

--- a/packages/speckit-analyzer/src/index.ts
+++ b/packages/speckit-analyzer/src/index.ts
@@ -46,3 +46,12 @@ export {
   FailureRulesSchema,
   type FailureRulesConfig,
 } from "./rules.js";
+
+export {
+  buildLabelTrendSeries,
+  rollingAverageSeries,
+  sparkline,
+  type LabelDailyRecord,
+  type LabelTrendPoint,
+  type LabelTrendSeries,
+} from "./trends.js";

--- a/packages/speckit-analyzer/src/trends.ts
+++ b/packages/speckit-analyzer/src/trends.ts
@@ -1,0 +1,121 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface LabelDailyRecord {
+  date: string; // YYYY-MM-DD
+  labels: Record<string, number>;
+}
+
+export interface LabelTrendPoint {
+  date: string;
+  value: number;
+}
+
+export type LabelTrendSeries = Record<string, LabelTrendPoint[]>;
+
+function toDate(value: string): Date {
+  const parsed = new Date(`${value}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`Invalid date: ${value}`);
+  }
+  return parsed;
+}
+
+function formatDate(date: Date): string {
+  return date.toISOString().slice(0, 10);
+}
+
+function enumerateDates(start: string, end: string): string[] {
+  const startDate = toDate(start);
+  const endDate = toDate(end);
+  if (startDate.getTime() > endDate.getTime()) {
+    return [];
+  }
+  const dates: string[] = [];
+  for (let current = startDate; current.getTime() <= endDate.getTime(); current = new Date(current.getTime() + MS_PER_DAY)) {
+    dates.push(formatDate(current));
+  }
+  return dates;
+}
+
+export function buildLabelTrendSeries(records: LabelDailyRecord[]): LabelTrendSeries {
+  if (records.length === 0) {
+    return {};
+  }
+  const sorted = [...records].sort((a, b) => a.date.localeCompare(b.date));
+  const first = sorted[0]?.date;
+  const last = sorted[sorted.length - 1]?.date;
+  if (!first || !last) {
+    return {};
+  }
+  const dateRange = enumerateDates(first, last);
+  const byDate = new Map<string, LabelDailyRecord>();
+  for (const record of sorted) {
+    byDate.set(record.date, record);
+  }
+  const labels = new Set<string>();
+  for (const record of sorted) {
+    for (const key of Object.keys(record.labels)) {
+      labels.add(key);
+    }
+  }
+  const series: LabelTrendSeries = {};
+  for (const label of labels) {
+    series[label] = dateRange.map((date) => ({
+      date,
+      value: byDate.get(date)?.labels[label] ?? 0,
+    }));
+  }
+  return series;
+}
+
+export function rollingAverageSeries(points: LabelTrendPoint[], windowSize: number): LabelTrendPoint[] {
+  if (windowSize <= 0) {
+    throw new Error(`windowSize must be positive, received ${windowSize}`);
+  }
+  if (points.length === 0) {
+    return [];
+  }
+  const result: LabelTrendPoint[] = [];
+  const values = points.map((point) => point.value);
+  let sum = 0;
+  for (let index = 0; index < values.length; index += 1) {
+    sum += values[index];
+    if (index >= windowSize) {
+      sum -= values[index - windowSize];
+    }
+    const divisor = Math.min(windowSize, index + 1);
+    result.push({
+      date: points[index].date,
+      value: Number((sum / divisor).toFixed(3)),
+    });
+  }
+  return result;
+}
+
+const SPARKLINE_BLOCKS = ["▁", "▂", "▃", "▄", "▅", "▆", "▇", "█"] as const;
+
+type SparklineOptions = {
+  length?: number;
+};
+
+export function sparkline(values: number[], options: SparklineOptions = {}): string {
+  const { length } = options;
+  if (!Array.isArray(values) || values.length === 0) {
+    return "—";
+  }
+  const subset = length && values.length > length ? values.slice(values.length - length) : values;
+  const min = Math.min(...subset);
+  const max = Math.max(...subset);
+  if (max === min) {
+    const block = max === 0 ? SPARKLINE_BLOCKS[0] : SPARKLINE_BLOCKS[SPARKLINE_BLOCKS.length - 1];
+    return block.repeat(subset.length);
+  }
+  const span = max - min;
+  return subset
+    .map((value) => {
+      const normalized = (value - min) / span;
+      const index = Math.round(normalized * (SPARKLINE_BLOCKS.length - 1));
+      return SPARKLINE_BLOCKS[Math.min(SPARKLINE_BLOCKS.length - 1, Math.max(0, index))];
+    })
+    .join("");
+}

--- a/packages/speckit-analyzer/test/trends.test.ts
+++ b/packages/speckit-analyzer/test/trends.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildLabelTrendSeries,
+  rollingAverageSeries,
+  sparkline,
+  type LabelDailyRecord,
+} from "../src/trends.js";
+
+describe("buildLabelTrendSeries", () => {
+  it("fills gaps between days and aggregates labels", () => {
+    const records: LabelDailyRecord[] = [
+      { date: "2024-01-01", labels: { alpha: 2 } },
+      { date: "2024-01-03", labels: { alpha: 1, beta: 5 } },
+    ];
+
+    const series = buildLabelTrendSeries(records);
+
+    expect(Object.keys(series)).toEqual(["alpha", "beta"]);
+    expect(series.alpha).toEqual([
+      { date: "2024-01-01", value: 2 },
+      { date: "2024-01-02", value: 0 },
+      { date: "2024-01-03", value: 1 },
+    ]);
+    expect(series.beta).toEqual([
+      { date: "2024-01-01", value: 0 },
+      { date: "2024-01-02", value: 0 },
+      { date: "2024-01-03", value: 5 },
+    ]);
+  });
+});
+
+describe("rollingAverageSeries", () => {
+  it("computes a trailing average using the requested window", () => {
+    const input = [
+      { date: "2024-01-01", value: 4 },
+      { date: "2024-01-02", value: 8 },
+      { date: "2024-01-03", value: 10 },
+    ];
+
+    const result = rollingAverageSeries(input, 2);
+
+    expect(result).toEqual([
+      { date: "2024-01-01", value: 4 },
+      { date: "2024-01-02", value: 6 },
+      { date: "2024-01-03", value: 9 },
+    ]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(rollingAverageSeries([], 3)).toEqual([]);
+  });
+});
+
+describe("sparkline", () => {
+  it("renders block characters scaled to the provided values", () => {
+    expect(sparkline([0, 2, 4, 8])).toEqual("▁▃▅█");
+  });
+
+  it("caps the output to the requested length", () => {
+    expect(sparkline([0, 1, 2, 3, 4], { length: 3 })).toEqual("▁▅█");
+  });
+
+  it("shows a flat line when values are constant", () => {
+    expect(sparkline([3, 3, 3])).toEqual("███");
+  });
+
+  it("returns an em dash for empty data", () => {
+    expect(sparkline([])).toEqual("—");
+  });
+});

--- a/scripts/analytics/trends.ts
+++ b/scripts/analytics/trends.ts
@@ -1,0 +1,197 @@
+import { execSync } from "node:child_process";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildLabelTrendSeries,
+  rollingAverageSeries,
+  sparkline,
+  type LabelDailyRecord,
+} from "@speckit/analyzer";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const ROOT = path.resolve(__dirname, "..", "..");
+const DOC_PATH = path.join(ROOT, "docs", "agent-trends.md");
+const METRICS_PATH = ".speckit/metrics.json";
+const REQUIREMENTS_PATH = ".speckit/requirements.jsonl";
+const WINDOW_DAYS = 7;
+const TOP_LABEL_LIMIT = 10;
+const SPARKLINE_LENGTH = 14;
+
+type GitCommit = {
+  hash: string;
+  date: string; // YYYY-MM-DD
+};
+
+type MetricsSnapshot = {
+  labels?: unknown;
+};
+
+type RequirementRecord = {
+  category?: unknown;
+  labels?: unknown;
+};
+
+function runGit(command: string): string | null {
+  try {
+    const output = execSync(`git ${command}`, {
+      cwd: ROOT,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return output.trim();
+  } catch {
+    return null;
+  }
+}
+
+function parseGitHistory(): GitCommit[] {
+  const history = runGit(`log --pretty=format:%H|%ct -- ${METRICS_PATH}`);
+  if (!history) return [];
+  return history
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const [hash, timestamp] = line.split("|");
+      if (!hash || !timestamp) return null;
+      const seconds = Number(timestamp);
+      if (!Number.isFinite(seconds)) return null;
+      const date = new Date(seconds * 1000).toISOString().slice(0, 10);
+      return { hash, date } satisfies GitCommit;
+    })
+    .filter((entry): entry is GitCommit => entry !== null);
+}
+
+function parseMetrics(content: string | null): string[] {
+  if (!content) return [];
+  try {
+    const parsed = JSON.parse(content) as MetricsSnapshot;
+    if (!parsed || typeof parsed !== "object") return [];
+    const rawLabels = Array.isArray(parsed.labels) ? parsed.labels : [];
+    return rawLabels.filter((label): label is string => typeof label === "string" && label.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+function parseRequirementLabels(content: string | null): string[] {
+  if (!content) return [];
+  const labels: string[] = [];
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      const record = JSON.parse(trimmed) as RequirementRecord;
+      if (Array.isArray(record.labels)) {
+        for (const label of record.labels) {
+          if (typeof label === "string" && label.trim().length > 0) {
+            labels.push(label.trim());
+          }
+        }
+      }
+      if (typeof record.category === "string" && record.category.trim().length > 0) {
+        labels.push(`category:${record.category.trim()}`);
+      }
+    } catch {
+      continue;
+    }
+  }
+  return labels;
+}
+
+function collectLabelRecords(): LabelDailyRecord[] {
+  const commits = parseGitHistory();
+  if (commits.length === 0) {
+    return [];
+  }
+  const daily = new Map<string, Map<string, number>>();
+  for (const commit of commits) {
+    const metricsContent = runGit(`show ${commit.hash}:${METRICS_PATH}`);
+    const requirementsContent = runGit(`show ${commit.hash}:${REQUIREMENTS_PATH}`);
+    const labels = [...parseMetrics(metricsContent), ...parseRequirementLabels(requirementsContent)];
+    if (labels.length === 0) continue;
+    const map = daily.get(commit.date) ?? new Map<string, number>();
+    for (const label of labels) {
+      map.set(label, (map.get(label) ?? 0) + 1);
+    }
+    daily.set(commit.date, map);
+  }
+  return Array.from(daily.entries())
+    .map(([date, labelMap]) => ({
+      date,
+      labels: Object.fromEntries(labelMap),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+function formatNumber(value: number): string {
+  return value.toFixed(2);
+}
+
+function buildReport(records: LabelDailyRecord[]): string {
+  const lines: string[] = [];
+  lines.push("# Agent Label Trends");
+  lines.push("");
+  lines.push(`Generated on ${new Date().toISOString()}.`);
+  lines.push("");
+  if (records.length === 0) {
+    lines.push(
+      "No historical label data was found in `.speckit/metrics.json` or `requirements.jsonl`. Upload analyzer artifacts to begin tracking trends."
+    );
+    return `${lines.join("\n")}\n`;
+  }
+  const firstDate = records[0]?.date;
+  const lastDate = records[records.length - 1]?.date;
+  if (firstDate && lastDate) {
+    lines.push(`Data range: **${firstDate} → ${lastDate}**.`);
+    lines.push("");
+  }
+  const series = buildLabelTrendSeries(records);
+  const entries = Object.entries(series)
+    .map(([label, points]) => {
+      const totals = points.reduce((sum, point) => sum + point.value, 0);
+      const averaged = rollingAverageSeries(points, WINDOW_DAYS);
+      const latestAverage = averaged.length > 0 ? averaged[averaged.length - 1]!.value : 0;
+      const spark = sparkline(
+        averaged.map((point) => point.value),
+        { length: SPARKLINE_LENGTH }
+      );
+      return {
+        label,
+        total: totals,
+        latestAverage,
+        spark,
+      };
+    })
+    .filter((entry) => entry.total > 0)
+    .sort((a, b) => b.total - a.total)
+    .slice(0, TOP_LABEL_LIMIT);
+
+  if (entries.length === 0) {
+    lines.push("No labels have been recorded yet.");
+    return `${lines.join("\n")}\n`;
+  }
+
+  lines.push("| Label | Total Count | 7-day Avg | Sparkline |");
+  lines.push("| --- | ---: | ---: | --- |");
+  for (const entry of entries) {
+    lines.push(`| \`${entry.label}\` | ${entry.total.toLocaleString()} | ${formatNumber(entry.latestAverage)} | ${entry.spark} |`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+async function main(): Promise<void> {
+  const records = collectLabelRecords();
+  const report = buildReport(records);
+  await fs.mkdir(path.dirname(DOC_PATH), { recursive: true });
+  await fs.writeFile(DOC_PATH, report, "utf8");
+}
+
+main().catch((error) => {
+  console.error("Failed to generate agent trends report:", error);
+  process.exitCode = 1;
+});
+

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,12 @@
     "moduleResolution": "node",
     "jsx": "react-jsx",
     "strict": true,
-    "types": ["node"]
+    "types": ["node"],
+    "baseUrl": ".",
+    "paths": {
+      "@speckit/analyzer": ["packages/speckit-analyzer/src/index.ts"],
+      "@speckit/analyzer/*": ["packages/speckit-analyzer/src/*"]
+    }
   },
   "include": ["scripts/**/*", "docs/**/*"]
 }


### PR DESCRIPTION
## Summary
- add a trends analytics script that mines metrics history and regenerates docs/agent-trends.md
- expose reusable trend utilities in @speckit/analyzer with regression coverage
- wire the dashboard update into the analyzer workflow and surface a pnpm helper command

## Testing
- pnpm --filter @speckit/analyzer test
- pnpm speckit:trends

------
https://chatgpt.com/codex/tasks/task_e_68d8029754bc832492192bd3779631c6