### PR TITLE
feat: enrich verification artifact with actionable checks

### DIFF
--- a/docs/speckit-run-coach.md
+++ b/docs/speckit-run-coach.md
@@ -64,7 +64,7 @@ pnpm speckit:inject                                      # Refresh prompt guardr
 Each coached run yields:
 
 - `.speckit/memo.json` — versioned lessons, guardrails, and checklist items keyed to the run ID.
-- `.speckit/verification.yaml` — CoVe verification stubs per requirement.
+- `.speckit/verification.yaml` — per-requirement commands, greps, and next-step probes.
 - `.speckit/metrics.json` — versioned metric snapshot and failure labels.
 - `.speckit/summary.md` — summary used for PR comments.
 - `RTM.md` — updated Run Traceability Matrix between managed markers.

--- a/docs/speckit-run-forensics.md
+++ b/docs/speckit-run-forensics.md
@@ -35,5 +35,6 @@ Forbidden labels enforced in CI: `process.read-before-write-fail`, `env.git-stat
 
 1. Run `pnpm speckit:analyze -- --raw-log sample-logs/*.log` and confirm `.speckit/memo.json` includes `version` and `generated_from.run_id`.
 2. Ensure `RTM.md` shows the managed table between `<!-- speckit:rtm:start -->` and `<!-- speckit:rtm:end -->`.
-3. Run `pnpm speckit:inject` and verify the coding agent brief now contains the latest memo guardrails + verification checklist.
-4. Commit refreshed artifacts before opening a PR so CI gates only enforce deltas from the latest run.
+3. Inspect `.speckit/verification.yaml` and rehearse each generated command/grep so the next run can replay the satisfied checks and tackle pending ones.
+4. Run `pnpm speckit:inject` and verify the coding agent brief now contains the latest memo guardrails + verification checklist.
+5. Commit refreshed artifacts before opening a PR so CI gates only enforce deltas from the latest run.

--- a/packages/speckit-analyzer/src/index.ts
+++ b/packages/speckit-analyzer/src/index.ts
@@ -35,6 +35,7 @@ export {
   attachEvidence,
   combineRequirements,
   extractImperative,
+  generateRequirementCheck,
 } from "./requirements.js";
 
 export { computeMetrics, summarizeMetrics } from "./metrics.js";

--- a/packages/speckit-analyzer/src/requirements.ts
+++ b/packages/speckit-analyzer/src/requirements.ts
@@ -1,5 +1,32 @@
 import type { RequirementRecord, RunEvent } from "./types.js";
 
+const CLI_KEYWORDS = [
+  "pnpm",
+  "npm",
+  "yarn",
+  "npx",
+  "go",
+  "python",
+  "pytest",
+  "pipenv",
+  "poetry",
+  "cargo",
+  "composer",
+  "bundle",
+  "rails",
+  "gradle",
+  "mvn",
+  "make",
+  "docker",
+  "kubectl",
+  "helm",
+  "bash",
+  "sh",
+];
+
+const FILE_EXTENSION_PATTERN =
+  /[A-Za-z0-9_./-]+\.(?:ts|tsx|js|jsx|cjs|mjs|json|yaml|yml|toml|ini|cfg|conf|md|mdx|txt|py|rs|go|java|kt|cs|rb|php|sh|bash|zsh|sql|css|scss|sass|less|html|vue|svelte)/;
+
 const imperativePatterns = [
   /^(must|should|ensure|create|add|update|implement|run|avoid|verify|write|check|document)\b/i,
   /^-\s*[A-Z]/,
@@ -110,4 +137,116 @@ export function combineRequirements(
     map.set(req.id, req);
   }
   return Array.from(map.values());
+}
+
+function sanitizeCommand(candidate: string): string {
+  return candidate.replace(/[\s.;:,]+$/, "").trim();
+}
+
+function extractInlineCommand(text: string): string | null {
+  const match = text.match(/`([^`]+)`/);
+  if (match) {
+    return sanitizeCommand(match[1]);
+  }
+  const quoted = text.match(/"([^"]*\b(?:pnpm|npm|yarn|npx|go|python|pytest|cargo|make|docker|kubectl)[^\"]*)"/i);
+  if (quoted) {
+    return sanitizeCommand(quoted[1]);
+  }
+  return null;
+}
+
+function detectDirectCommand(text: string): string | null {
+  const pattern = new RegExp(`\\b(${CLI_KEYWORDS.join("|")})\\b[^\\n]*`, "i");
+  const match = text.match(pattern);
+  if (!match) return null;
+  const truncated = match[0].split(/\b(?:and|then|after)\b/i)[0];
+  return sanitizeCommand(truncated);
+}
+
+function detectFileTarget(text: string): string | null {
+  const match = text.match(FILE_EXTENSION_PATTERN);
+  if (!match) return null;
+  return match[0];
+}
+
+function buildSearchFallback(req: RequirementRecord): string {
+  const withoutCode = req.text.replace(/`[^`]+`/g, " ");
+  const tokens = withoutCode
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, " ")
+    .split(/\s+/)
+    .filter((token) => token.length > 3);
+  const phrase = tokens.slice(0, 3).join(" ");
+  if (phrase) {
+    return `rg "${phrase}" -n`;
+  }
+  return `rg "${req.id.toLowerCase()}" -n`;
+}
+
+function inferVerificationCommand(req: RequirementRecord): string {
+  const inline = extractInlineCommand(req.text);
+  if (inline) return inline;
+
+  const direct = detectDirectCommand(req.text);
+  if (direct) return direct;
+
+  const normalized = req.text.toLowerCase();
+
+  if (normalized.includes("lint")) {
+    return "pnpm lint";
+  }
+  if (normalized.includes("type check") || normalized.includes("type-check") || normalized.includes("typecheck")) {
+    return "pnpm typecheck";
+  }
+  if (normalized.includes("coverage")) {
+    return "pnpm test -- --coverage";
+  }
+  if (normalized.includes("build")) {
+    return "pnpm build";
+  }
+  if (normalized.includes("format") || normalized.includes("prettier")) {
+    return "pnpm format";
+  }
+
+  const fileTarget = detectFileTarget(req.text);
+  if (fileTarget) {
+    return `git diff --stat ${fileTarget}`;
+  }
+
+  if (
+    req.category === "validation" ||
+    normalized.includes("test") ||
+    normalized.includes("assert") ||
+    normalized.includes("verify")
+  ) {
+    return "pnpm test";
+  }
+  if (normalized.includes("doc") || normalized.includes("readme") || normalized.includes("guide")) {
+    return "pnpm docs:build";
+  }
+
+  return buildSearchFallback(req);
+}
+
+function formatEvidenceNote(req: RequirementRecord): string {
+  if (req.evidence.length === 0) {
+    return "No run evidence captured yet.";
+  }
+  return `Evidence: ${req.evidence.join(", ")}.`;
+}
+
+export function generateRequirementCheck(req: RequirementRecord): string {
+  const command = inferVerificationCommand(req);
+  const evidenceNote = formatEvidenceNote(req);
+  switch (req.status) {
+    case "satisfied":
+      return `Regression guard: run \`${command}\` to reconfirm. ${evidenceNote}`;
+    case "violated":
+      return `Remediate failure and re-run \`${command}\`. ${evidenceNote}`;
+    case "in-progress":
+      return `Next step: execute \`${command}\` and capture output as evidence. ${evidenceNote}`;
+    case "unknown":
+    default:
+      return `Plan check: run \`${command}\` to establish coverage. ${evidenceNote}`;
+  }
 }

--- a/packages/speckit-analyzer/test/requirements.verification.test.ts
+++ b/packages/speckit-analyzer/test/requirements.verification.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import type { RequirementRecord } from "../src/types.js";
+import { generateRequirementCheck } from "../src/requirements.js";
+
+describe("generateRequirementCheck", () => {
+  it("returns reproducible commands for satisfied requirements", () => {
+    const requirement: RequirementRecord = {
+      id: "REQ-001",
+      text: "Run `pnpm test --filter unit` to cover the new parser branch.",
+      status: "satisfied",
+      evidence: ["event-42"],
+    };
+
+    expect(generateRequirementCheck(requirement)).toBe(
+      "Regression guard: run `pnpm test --filter unit` to reconfirm. Evidence: event-42."
+    );
+  });
+
+  it("suggests next verification steps for pending work", () => {
+    const requirement: RequirementRecord = {
+      id: "REQ-002",
+      text: "Ensure lint passes before shipping the patch.",
+      status: "violated",
+      evidence: [],
+    };
+
+    expect(generateRequirementCheck(requirement)).toBe(
+      "Remediate failure and re-run `pnpm lint`. No run evidence captured yet."
+    );
+  });
+
+  it("falls back to actionable greps when no command is present", () => {
+    const requirement: RequirementRecord = {
+      id: "REQ-003",
+      text: "Document the behavior change in README.md and changelog.",
+      status: "unknown",
+      evidence: [],
+    };
+
+    expect(generateRequirementCheck(requirement)).toBe(
+      "Plan check: run `git diff --stat README.md` to establish coverage. No run evidence captured yet."
+    );
+  });
+});

--- a/scripts/speckit-analyze-run.ts
+++ b/scripts/speckit-analyze-run.ts
@@ -10,6 +10,7 @@ import {
   MEMO_ARTIFACT_VERSION,
   METRICS_ARTIFACT_VERSION,
   RUN_ARTIFACT_SCHEMA_VERSION,
+  generateRequirementCheck,
 } from "@speckit/analyzer";
 
 const __filename = fileURLToPath(import.meta.url);
@@ -497,7 +498,7 @@ function buildVerification(requirements: RequirementRecord[]): VerificationArtif
       description: req.text,
       status: req.status,
       evidence: req.evidence,
-      check: req.status === "satisfied" ? "Confirmed via run evidence" : "Pending manual verification",
+      check: generateRequirementCheck(req),
     })),
   };
 }

--- a/scripts/writers/artifacts.ts
+++ b/scripts/writers/artifacts.ts
@@ -7,6 +7,7 @@ import {
   type Metrics,
   type RequirementRecord,
   type RunArtifact,
+  generateRequirementCheck,
 } from "@speckit/analyzer";
 import type { ExperimentAssignment } from "../config/experiments.js";
 import { updateMemoHistory } from "./memo-history.js";
@@ -117,7 +118,7 @@ function buildVerification(requirements: RequirementRecord[]): VerificationArtif
       description: req.text,
       status: req.status,
       evidence: req.evidence,
-      check: req.status === "satisfied" ? "Confirmed via run evidence" : "Pending manual verification",
+      check: generateRequirementCheck(req),
     })),
   };
 }


### PR DESCRIPTION
## Summary
- generate deterministic verification commands for requirements and use them in the verification artifact builders
- add analyzer tests that cover multiple requirement statuses and assert the emitted checks
- document how to rehearse the richer verification plan surfaced in `.speckit/verification.yaml`

## Testing
- pnpm test --filter @speckit/analyzer

------
https://chatgpt.com/codex/tasks/task_e_68d80efbea20832480576c0afdc457a0