### PR TITLE
feat: preserve sanitizer hits across analyzer reruns

### DIFF
--- a/packages/speckit-analyzer/test/run-analysis-sanitizer.test.ts
+++ b/packages/speckit-analyzer/test/run-analysis-sanitizer.test.ts
@@ -1,0 +1,67 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@speckit/analyzer", async () => {
+  const actual = await vi.importActual<typeof import("../src/index.js")>("../src/index.js");
+  return {
+    ...actual,
+    analyze: vi.fn(async (options: { runId: string }) => ({
+      run: {
+        runId: options.runId,
+        sourceLogs: [],
+        startedAt: null,
+        finishedAt: null,
+        events: [],
+        metadata: undefined,
+      },
+      requirements: [],
+      metrics: {
+        ReqCoverage: 0,
+        BacktrackRatio: 0,
+        ToolPrecisionAt1: 0,
+        EditLocality: 0,
+        ReflectionDensity: 0,
+        TTFPSeconds: null,
+      },
+      labels: new Set<string>(),
+      normalized: {} as any,
+    })),
+    summarizeMetrics: vi.fn(() => []),
+  };
+});
+
+vi.mock("@speckit/analyzer/adapters/node", () => ({
+  createFileLogSource: vi.fn(async (filePath: string) => ({ filePath })),
+  loadFailureRulesFromFs: vi.fn(async () => []),
+}));
+
+vi.mock("../../../scripts/writers/rtm.js", () => ({
+  updateRTM: vi.fn(async () => {}),
+}));
+
+vi.mock("../../../scripts/config/experiments.js", () => ({
+  loadExperimentAssignments: vi.fn(async () => []),
+}));
+
+describe("runAnalysis sanitizer regression", () => {
+  it("keeps sanitizer hits from the existing report", async () => {
+    const rootDir = path.resolve(__dirname, "../../..");
+    const outDir = await mkdtemp(path.join(tmpdir(), "speckit-sanitizer-"));
+    try {
+      await writeFile(path.join(outDir, "sanitizer-report.json"), JSON.stringify({ hits: 5 }));
+      const logPaths = [path.join(outDir, "run.ndjson")];
+      const { runAnalysis } = await import("../../../scripts/run-analysis.ts");
+
+      await runAnalysis(logPaths, { runId: "run-test", outDir }, { rootDir });
+
+      const metricsRaw = await readFile(path.join(outDir, "metrics.json"), "utf8");
+      const metrics = JSON.parse(metricsRaw);
+      expect(metrics.sanitizer_hits).toBe(5);
+    } finally {
+      await rm(outDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/scripts/run-analysis.ts
+++ b/scripts/run-analysis.ts
@@ -1,0 +1,190 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import {
+  analyze,
+  summarizeMetrics,
+  type AnalyzerResult,
+  type NormalizedLog,
+  type RequirementRecord,
+} from "@speckit/analyzer";
+import { createFileLogSource, loadFailureRulesFromFs } from "@speckit/analyzer/adapters/node";
+
+import { writeArtifacts } from "./writers/artifacts.js";
+import { updateRTM } from "./writers/rtm.js";
+import { loadExperimentAssignments } from "./config/experiments.js";
+import type { ExperimentAssignment } from "./config/experiments.js";
+
+export interface RunAnalysisResult {
+  runId: string;
+  requirements: RequirementRecord[];
+  metricsSummary: ReturnType<typeof summarizeMetrics>;
+  labels: Set<string>;
+  normalized: NormalizedLog;
+  artifacts: Awaited<ReturnType<typeof writeArtifacts>>;
+  experiments: ExperimentAssignment[];
+}
+
+export interface RunAnalysisOptions {
+  runId?: string;
+  outDir?: string;
+}
+
+function coerceHitCount(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === "string" && value.trim().length > 0) {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : undefined;
+  }
+  return undefined;
+}
+
+function sumHitCounts(entries: unknown): number | undefined {
+  if (!Array.isArray(entries)) return undefined;
+  let total = 0;
+  let found = false;
+  for (const entry of entries) {
+    let candidate: number | undefined;
+    if (typeof entry === "object" && entry !== null) {
+      const record = entry as Record<string, unknown>;
+      candidate =
+        coerceHitCount(record.hits) ??
+        coerceHitCount(record.count) ??
+        coerceHitCount(record.total) ??
+        coerceHitCount(record.value);
+    } else {
+      candidate = coerceHitCount(entry);
+    }
+    if (candidate !== undefined) {
+      found = true;
+      total += candidate;
+    }
+  }
+  return found ? total : undefined;
+}
+
+function extractSanitizerHits(report: unknown): number | undefined {
+  if (report === null || report === undefined) return undefined;
+  const direct = coerceHitCount(report);
+  if (direct !== undefined) {
+    return direct;
+  }
+  if (Array.isArray(report)) {
+    return sumHitCounts(report);
+  }
+  if (typeof report === "object") {
+    const record = report as Record<string, unknown>;
+    const keys = ["hits", "total_hits", "totalHits", "sanitizer_hits", "sanitizerHits", "count", "value"];
+    for (const key of keys) {
+      const candidate = coerceHitCount(record[key]);
+      if (candidate !== undefined) {
+        return candidate;
+      }
+    }
+    const nestedKeys = ["entries", "reports", "redactions", "records"];
+    for (const key of nestedKeys) {
+      const candidate = sumHitCounts(record[key]);
+      if (candidate !== undefined) {
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}
+
+async function readSanitizerHits(outDir: string, rootDir: string): Promise<number | undefined> {
+  const reportPath = path.join(outDir, "sanitizer-report.json");
+  try {
+    const raw = await fs.readFile(reportPath, "utf8");
+    const parsed = JSON.parse(raw) as unknown;
+    return extractSanitizerHits(parsed);
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError?.code === "ENOENT") {
+      return undefined;
+    }
+    console.warn(
+      `[speckit] Unable to read sanitizer report at ${path.relative(rootDir, reportPath)}: ${nodeError?.message ?? error}`
+    );
+    return undefined;
+  }
+}
+
+type AnalyzerArtifactsInput = Pick<AnalyzerResult, "run" | "requirements" | "metrics" | "labels"> & {
+  rootDir: string;
+  outDir: string;
+  experiments: ExperimentAssignment[];
+};
+
+export async function emitAnalyzerArtifacts(
+  options: AnalyzerArtifactsInput
+): Promise<Awaited<ReturnType<typeof writeArtifacts>>> {
+  const sanitizerHits = await readSanitizerHits(options.outDir, options.rootDir);
+  return writeArtifacts({
+    rootDir: options.rootDir,
+    outDir: options.outDir,
+    run: options.run,
+    requirements: options.requirements,
+    metrics: options.metrics,
+    labels: options.labels,
+    sanitizerHits,
+    experiments: options.experiments,
+  });
+}
+
+export async function runAnalysis(
+  logPaths: string[],
+  options: RunAnalysisOptions,
+  context: { rootDir: string }
+): Promise<RunAnalysisResult> {
+  if (logPaths.length === 0) {
+    throw new Error("No log files found. Provide --log <glob> or ensure runs/ contains logs.");
+  }
+  const resolvedOutDir = options.outDir
+    ? path.isAbsolute(options.outDir)
+      ? options.outDir
+      : path.join(context.rootDir, options.outDir)
+    : path.join(context.rootDir, ".speckit");
+  const sources = await Promise.all(logPaths.map((filePath) => createFileLogSource(filePath)));
+  const rules = await loadFailureRulesFromFs(context.rootDir, resolvedOutDir);
+  const runId = options.runId ?? `run-${Date.now()}`;
+  const experiments = await loadExperimentAssignments({ rootDir: context.rootDir, seed: runId });
+  const metadata =
+    experiments.length > 0
+      ? {
+          experiments: experiments.map((experiment) => ({
+            key: experiment.key,
+            description: experiment.description,
+            variant: experiment.variantKey,
+            variant_description: experiment.variantDescription,
+            bucket: experiment.bucket,
+            metadata: experiment.metadata,
+          })),
+        }
+      : undefined;
+  const analysis = await analyze({ sources, rules, runId, metadata });
+  if (metadata && !analysis.run.metadata) {
+    analysis.run.metadata = metadata;
+  }
+  const artifacts = await emitAnalyzerArtifacts({
+    rootDir: context.rootDir,
+    outDir: resolvedOutDir,
+    run: analysis.run,
+    requirements: analysis.requirements,
+    metrics: analysis.metrics,
+    labels: analysis.labels,
+    experiments,
+  });
+  await updateRTM({ rootDir: context.rootDir, outDir: resolvedOutDir, rtmPath: undefined });
+  return {
+    runId: analysis.run.runId,
+    requirements: analysis.requirements,
+    metricsSummary: summarizeMetrics(analysis.metrics),
+    labels: analysis.labels,
+    normalized: analysis.normalized,
+    artifacts,
+    experiments,
+  };
+}


### PR DESCRIPTION
## Summary
- add a shared run-analysis helper that carries sanitizer hits into artifact writes
- reuse the helper for CLI quick actions so memo and verification refreshes keep sanitizer counts
- document sanitizer persistence in the run-forensics guide and add a regression test

## Testing
- pnpm --filter @speckit/analyzer test

------
https://chatgpt.com/codex/tasks/task_e_68d81c4599c08324b937e7cdec7f23e9