### PR TITLE
Include memo history artifact in analyze workflow auto-commit

### DIFF
--- a/.github/workflows/speckit-analyze-run.yml
+++ b/.github/workflows/speckit-analyze-run.yml
@@ -100,6 +100,7 @@ jobs:
             .speckit/*.yaml
             .speckit/*.md
             .speckit/requirements.jsonl
+            .speckit/memo-history.jsonl
             docs/agent-trends.md
             RTM.md
             docs/internal/agents/coding-agent-brief.md


### PR DESCRIPTION
## Summary
- add the generated `.speckit/memo-history.jsonl` file to the auto-commit whitelist in the analyze workflow so memo history is preserved

## Testing
- pnpm speckit:analyze -- --raw-log packages/speckit-analyzer/test/fixtures/successful-run.ndjson *(fails: tsx cannot parse JSX in scripts/cli.ts; used runAnalysis helper instead)*
- node --import tsx -e "import path from 'node:path'; import { runAnalysis } from './scripts/run-analysis.ts'; const root=process.cwd(); runAnalysis([path.join(root,'packages/speckit-analyzer/test/fixtures/successful-run.ndjson')], {}, { rootDir: root }).then(()=>process.exit(0)).catch((error)=>{console.error(error);process.exit(1);});"
- pnpm test (pre-commit hook)


------
https://chatgpt.com/codex/tasks/task_e_68d82772ec8c8324aefb0932f400ff5c