### PR TITLE
chore(meta): close gaps surfaced by meta sanity pass

### DIFF
--- a/.github/workflows/speckit-upload-logs.yml
+++ b/.github/workflows/speckit-upload-logs.yml
@@ -32,30 +32,35 @@ jobs:
           node <<'NODE'
           const fs = require('fs');
           const path = require('path');
-          const patterns = [
-            { regex: /(sk-[a-z0-9]{20,})/gi, replacement: '[redacted-token]' },
-            { regex: /(gh[pous]_[a-z0-9]{20,})/gi, replacement: '[redacted-token]' },
-            { regex: /(eyJ[0-9a-zA-Z_-]{10,}\.[0-9a-zA-Z_-]{10,}\.[0-9a-zA-Z_-]{10,})/g, replacement: '[redacted-jwt]' },
-            { regex: /(sessionid=)[^;\s]+/gi, replacement: '$1[redacted]' },
-            { regex: /(cookie:)[^\n]+/gi, replacement: '$1 [redacted-cookie]' },
-            { regex: /(https?:\/\/[^\s]+:[^@\s]+@)/gi, replacement: '[redacted-url]' },
-          ];
+          const patternsPath = path.join(process.cwd(), 'packages', 'speckit-core', 'patterns', 'sanitizer-patterns.json');
+          const definitions = JSON.parse(fs.readFileSync(patternsPath, 'utf8'));
+          const patterns = definitions.map(def => {
+            const flags = def.flags ? (def.flags.includes('g') ? def.flags : `${def.flags}g`) : 'g';
+            return {
+              pattern: def.pattern,
+              regex: new RegExp(def.pattern, flags),
+              replacement: def.replacement,
+            };
+          });
           const root = process.cwd();
           const sourceDir = path.join(root, 'runs');
           const destDir = path.join(root, 'sanitized-logs');
           let hits = 0;
+          const patternHits = new Map();
 
           function sanitizeText(text) {
             let next = text;
             for (const pattern of patterns) {
-              next = next.replace(pattern.regex, (match, ...rest) => {
-                hits += 1;
-                if (pattern.replacement.includes('$1')) {
-                  const groups = rest.slice(0, -2);
-                  return pattern.replacement.replace('$1', groups[0]);
-                }
-                return pattern.replacement;
-              });
+              pattern.regex.lastIndex = 0;
+              const matches = next.match(pattern.regex);
+              if (!matches || matches.length === 0) {
+                continue;
+              }
+              hits += matches.length;
+              patternHits.set(pattern.pattern, (patternHits.get(pattern.pattern) ?? 0) + matches.length);
+              pattern.regex.lastIndex = 0;
+              next = next.replace(pattern.regex, pattern.replacement);
+              pattern.regex.lastIndex = 0;
             }
             return next;
           }
@@ -86,7 +91,14 @@ jobs:
           walk(sourceDir);
           fs.writeFileSync(
             path.join(destDir, 'sanitizer-report.json'),
-            JSON.stringify({ hits }, null, 2)
+            JSON.stringify(
+              {
+                hits,
+                pattern_hits: Object.fromEntries(patternHits.entries()),
+              },
+              null,
+              2
+            )
           );
           console.log(`Sanitized logs with ${hits} potential secret hits.`);
           NODE

--- a/.github/workflows/speckit-verify.yml
+++ b/.github/workflows/speckit-verify.yml
@@ -25,6 +25,8 @@ jobs:
         run: node packages/speckit-cli/dist/cli.js gen --write
       - name: Audit generated docs
         run: node packages/speckit-cli/dist/cli.js audit
+      - name: Validate analyzer artifacts
+        run: pnpm speckit:validate-artifacts
       - name: Fail if generated docs drift
         run: git diff --exit-code || (echo "Generated docs drift detected. Run 'speckit gen --write' and commit." && exit 1)
       - name: Run Speckit Doctor

--- a/.speckit/meta-sanity-report.md
+++ b/.speckit/meta-sanity-report.md
@@ -1,0 +1,16 @@
+# Meta Sanity Pass Report
+
+- [x] Workflows `.github/workflows/speckit-analyze-run.yml` and `speckit-upload-logs.yml` already present; sanitizer step now sources shared patterns.
+- [x] Core API exposed via `@speckit/core` with `analyzeLogs`, `sanitizeLogs`, and metric helpers.
+- [x] Schemas added under `schemas/` for metrics, summary, and requirements artifacts.
+- [x] Validator job (`pnpm speckit:validate-artifacts`) wired into `speckit-verify` CI.
+- [x] Sanitizer patterns centralized (`packages/speckit-core/patterns/sanitizer-patterns.json`) with broader coverage and unit tests.
+- [x] Provider parsers for OpenAI, Anthropic, Vercel AI SDK, LangChain/LangGraph, and MCP logs emit normalized analyzer events.
+- [x] PR summary comment now includes artifact links and next-run hints via enriched `.speckit/summary.md` + `.speckit/summary.json`.
+- [x] Policy updated with graduation badge and ADR for feature rollout decisions.
+
+## Decisions
+
+1. Established `@speckit/core` as the public entry point for log analysis, sanitization, and metric presentation to keep consumers off of internal scripts.
+2. Added schema validation to CI so `.speckit` artifacts fail fast when structure drifts.
+3. Documented feature graduation guardrails to align with compliance expectations and surfaced a reusable badge for feature status.

--- a/.speckit/summary.json
+++ b/.speckit/summary.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "generated_at": "2025-09-27T18:41:33.094Z",
+  "run": {
+    "id": "test-run",
+    "sources": [
+      "sample-logs/run.log"
+    ],
+    "events": 9
+  },
+  "metrics": {
+    "ReqCoverage": 0,
+    "ToolPrecisionAt1": 0,
+    "BacktrackRatio": 0,
+    "EditLocality": 0,
+    "ReflectionDensity": 0,
+    "TTFPSeconds": null,
+    "sanitizer_hits": 0
+  },
+  "labels": [],
+  "requirements": [
+    {
+      "id": "REQ-01",
+      "status": "in-progress",
+      "text": "Update README with agent run forensics quick start.",
+      "evidence": [
+        "line-6"
+      ]
+    },
+    {
+      "id": "REQ-02",
+      "status": "in-progress",
+      "text": "Ensure RTM table includes latest requirement.",
+      "evidence": [
+        "line-7"
+      ]
+    }
+  ],
+  "hints": [
+    "Upload sanitized logs so schema validation stays green."
+  ],
+  "artifacts": {
+    "run": ".speckit/Run.json",
+    "requirements": ".speckit/requirements.jsonl",
+    "metrics": ".speckit/metrics.json",
+    "summary": ".speckit/summary.md",
+    "summary_json": ".speckit/summary.json",
+    "memo": ".speckit/memo.json",
+    "verification": ".speckit/verification.yaml"
+  }
+}

--- a/docs/internal/adr/0003-feature-graduation-badge.md
+++ b/docs/internal/adr/0003-feature-graduation-badge.md
@@ -1,0 +1,7 @@
+# ADR 0003: Feature Graduation Badge & Policy
+
+- **Status:** Accepted
+- **Date:** 2024-10-25
+- **Context:** SpecKit needs a consistent signal for when experimental capabilities become part of the supported surface area.
+- **Decision:** Introduce a `feature-graduated` badge and publish the graduation policy in `policy/feature-graduation.md`. Graduation requires schema validation, RTM coverage, adoption signals, and a documented support plan. `.speckit/summary.json` provides the canonical artifact references.
+- **Consequences:** PRs that graduate features must update the README with the badge, link to the ADR, and attach the relevant summary/CI evidence. CI enforces schema validation so regressions surface quickly.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "speckit:analyze": "tsx scripts/cli.ts analyze",
     "speckit:replay": "tsx scripts/cli.ts replay",
     "speckit:inject": "tsx scripts/cli.ts inject",
-    "speckit:trends": "tsx scripts/analytics/trends.ts"
+    "speckit:trends": "tsx scripts/analytics/trends.ts",
+    "speckit:validate-artifacts": "tsx scripts/validators/validate-artifacts.ts"
   },
   "keywords": [
     "spec-driven-development",
@@ -56,7 +57,9 @@
     "tsx": "^4.19.1",
     "yaml": "^2.6.0",
     "yargs": "^17.7.2",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1"
   },
   "pnpm": {
     "overrides": {

--- a/packages/speckit-analyzer/package.json
+++ b/packages/speckit-analyzer/package.json
@@ -20,9 +20,14 @@
   },
   "sideEffects": false,
   "scripts": {
-    "build": "tsup src/index.ts src/adapters/node.ts --format esm,cjs --dts --clean --target es2022",
+    "build": "tsup src/index.ts src/adapters/node.ts src/adapters/providers.ts --format esm,cjs --dts --clean --target es2022",
     "test": "vitest run"
-  },
+    },
+    "./adapters/providers": {
+      "types": "./dist/adapters/providers.d.ts",
+      "import": "./dist/adapters/providers.mjs",
+      "require": "./dist/adapters/providers.cjs"
+    },
   "dependencies": {
     "@noble/hashes": "^1.4.0",
     "strip-ansi": "^7.1.0",

--- a/packages/speckit-analyzer/src/adapters/providers.ts
+++ b/packages/speckit-analyzer/src/adapters/providers.ts
@@ -1,0 +1,219 @@
+import type { RunEvent } from "../types.js";
+
+function ensureArray<T>(input: T | T[] | undefined | null): T[] {
+  if (!input) return [];
+  return Array.isArray(input) ? input : [input];
+}
+
+function toTimestamp(value: unknown): string {
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return new Date(value * (value < 1_000_000_000_000 ? 1000 : 1)).toISOString();
+  }
+  if (typeof value === "string") {
+    const numeric = Number(value);
+    if (Number.isFinite(numeric)) {
+      return new Date(numeric * (numeric < 1_000_000_000_000 ? 1000 : 1)).toISOString();
+    }
+    const parsed = new Date(value);
+    if (!Number.isNaN(parsed.getTime())) {
+      return parsed.toISOString();
+    }
+  }
+  return new Date().toISOString();
+}
+
+function coerceText(value: unknown): string {
+  if (value === null || value === undefined) {
+    return "";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => coerceText(item)).filter(Boolean).join("\n");
+  }
+  if (typeof value === "object") {
+    const record = value as Record<string, unknown>;
+    if (typeof record.text === "string") {
+      return record.text;
+    }
+    if (Array.isArray(record.content)) {
+      return record.content.map((item) => coerceText(item)).filter(Boolean).join("\n");
+    }
+    if (typeof record.value === "string") {
+      return record.value;
+    }
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function createEvent(index: number, data: Partial<RunEvent>): RunEvent {
+  return {
+    id: data.id ?? `provider-${index + 1}`,
+    timestamp: data.timestamp ?? new Date().toISOString(),
+    kind: data.kind ?? "log",
+    subtype: data.subtype,
+    role: data.role,
+    input: data.input,
+    output: data.output,
+    error: data.error,
+    files_changed: data.files_changed,
+    meta: data.meta,
+  };
+}
+
+export interface OpenAiChatLog {
+  id?: string;
+  created?: number | string;
+  model?: string;
+  messages?: Array<{ role?: string; content?: unknown; created_at?: string | number }>;
+  request?: { messages?: Array<{ role?: string; content?: unknown; created_at?: string | number }> };
+  response?: { choices?: Array<{ message?: { role?: string; content?: unknown }; finish_reason?: string | null }> };
+}
+
+export function openAiChatCompletionsToEvents(log: OpenAiChatLog | OpenAiChatLog[]): RunEvent[] {
+  const records = ensureArray(log);
+  const events: RunEvent[] = [];
+  let counter = 0;
+
+  for (const record of records) {
+    const baseMeta: Record<string, unknown> = {};
+    if (record.model) {
+      baseMeta.model = record.model;
+    }
+    const messages = ensureArray(record.request?.messages ?? record.messages);
+    for (const message of messages) {
+      const content = coerceText(message?.content);
+      events.push(
+        createEvent(counter++, {
+          id: message?.created_at ? `openai-msg-${message.created_at}` : undefined,
+          timestamp: message?.created_at ? toTimestamp(message.created_at) : toTimestamp(record.created),
+          kind: "log",
+          subtype: typeof message?.role === "string" ? message.role : "message",
+          role: typeof message?.role === "string" ? message.role : undefined,
+          input: message?.role === "user" ? content : undefined,
+          output: message?.role === "assistant" ? content : undefined,
+          meta: { provider: "openai", ...baseMeta },
+        })
+      );
+    }
+
+    const choices = ensureArray(record.response?.choices);
+    for (const choice of choices) {
+      const content = coerceText(choice?.message?.content);
+      events.push(
+        createEvent(counter++, {
+          timestamp: toTimestamp(record.created),
+          kind: "run",
+          subtype: "assistant",
+          role: choice?.message?.role ?? "assistant",
+          output: content,
+          meta: { provider: "openai", finish_reason: choice?.finish_reason ?? undefined, ...baseMeta },
+        })
+      );
+    }
+  }
+
+  return events;
+}
+
+export interface AnthropicMessageLog {
+  id?: string;
+  model?: string;
+  role?: string;
+  content?: unknown;
+  created_at?: string | number;
+  usage?: Record<string, unknown>;
+  metadata?: Record<string, unknown>;
+}
+
+export function anthropicMessagesToEvents(log: AnthropicMessageLog | AnthropicMessageLog[]): RunEvent[] {
+  const messages = ensureArray(log);
+  return messages.map((message, index) =>
+    createEvent(index, {
+      id: message.id,
+      timestamp: toTimestamp(message.created_at),
+      kind: message.role === "user" ? "plan" : "run",
+      subtype: message.role ?? undefined,
+      role: message.role ?? undefined,
+      input: message.role === "user" ? coerceText(message.content) : undefined,
+      output: message.role !== "user" ? coerceText(message.content) : undefined,
+      meta: { provider: "anthropic", model: message.model, usage: message.usage, metadata: message.metadata },
+    })
+  );
+}
+
+export interface VercelAiLogEntry {
+  type?: string;
+  role?: string;
+  content?: unknown;
+  timestamp?: string | number;
+  data?: Record<string, unknown>;
+}
+
+export function vercelAiMessagesToEvents(log: VercelAiLogEntry | VercelAiLogEntry[]): RunEvent[] {
+  const entries = ensureArray(log);
+  return entries.map((entry, index) =>
+    createEvent(index, {
+      timestamp: toTimestamp(entry.timestamp),
+      kind: entry.type === "tool" ? "tool" : "log",
+      subtype: entry.type ?? undefined,
+      role: entry.role ?? undefined,
+      output: coerceText(entry.content ?? entry.data?.content),
+      meta: { provider: "vercel-ai", data: entry.data },
+    })
+  );
+}
+
+export interface LangChainRunLog {
+  id?: string;
+  name?: string;
+  type?: string;
+  start_time?: string | number;
+  end_time?: string | number;
+  inputs?: Record<string, unknown>;
+  outputs?: Record<string, unknown>;
+  tags?: string[];
+}
+
+export function langChainRunsToEvents(log: LangChainRunLog | LangChainRunLog[]): RunEvent[] {
+  const runs = ensureArray(log);
+  return runs.map((run, index) =>
+    createEvent(index, {
+      id: run.id,
+      timestamp: toTimestamp(run.start_time ?? run.end_time),
+      kind: run.type === "tool" ? "tool" : run.type === "chain" ? "run" : "log",
+      subtype: run.name ?? run.type,
+      input: run.inputs ?? undefined,
+      output: run.outputs ?? undefined,
+      meta: { provider: "langchain", tags: run.tags },
+    })
+  );
+}
+
+export interface McpEventLog {
+  type?: string;
+  message?: string | { content?: unknown };
+  error?: unknown;
+  created_at?: string | number;
+  metadata?: Record<string, unknown>;
+}
+
+export function mcpEventsToRunEvents(log: McpEventLog | McpEventLog[]): RunEvent[] {
+  const records = ensureArray(log);
+  return records.map((record, index) => {
+    const kind = record.type === "tool" ? "tool" : record.type === "error" ? "error" : "log";
+    const output = coerceText((record.message as any)?.content ?? record.message);
+    return createEvent(index, {
+      timestamp: toTimestamp(record.created_at),
+      kind,
+      output,
+      error: kind === "error" ? record.error ?? output : undefined,
+      meta: { provider: "mcp", metadata: record.metadata },
+    });
+  });
+}

--- a/packages/speckit-analyzer/test/artifacts.test.ts
+++ b/packages/speckit-analyzer/test/artifacts.test.ts
@@ -62,6 +62,11 @@ describe("artifact writer", () => {
     const metricsRaw = await readFile(path.join(outDir, "metrics.json"), "utf8");
     const metricsArtifact = JSON.parse(metricsRaw);
     expect(metricsArtifact.version).toBe(METRICS_ARTIFACT_VERSION);
+
+    const summaryRaw = await readFile(path.join(outDir, "summary.json"), "utf8");
+    const summary = JSON.parse(summaryRaw);
+    expect(summary.version).toBe(1);
+    expect(summary.metrics.sanitizer_hits).toBe(0);
   });
 
   it("records deterministic verification commands for each requirement", async () => {

--- a/packages/speckit-analyzer/test/providers.test.ts
+++ b/packages/speckit-analyzer/test/providers.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  anthropicMessagesToEvents,
+  langChainRunsToEvents,
+  mcpEventsToRunEvents,
+  openAiChatCompletionsToEvents,
+  vercelAiMessagesToEvents,
+} from "../src/adapters/providers.js";
+
+describe("provider adapters", () => {
+  it("normalizes OpenAI chat completion payloads", () => {
+    const events = openAiChatCompletionsToEvents({
+      model: "gpt-4o-mini",
+      request: {
+        messages: [
+          { role: "user", content: "Summarize" },
+          { role: "assistant", content: "Summary" },
+        ],
+      },
+      response: {
+        choices: [{ message: { role: "assistant", content: "Ok" }, finish_reason: "stop" }],
+      },
+    });
+    expect(events.length).toBeGreaterThanOrEqual(3);
+    expect(events[0].role).toBe("user");
+    expect(events[0].input).toBe("Summarize");
+  });
+
+  it("normalizes Anthropic message logs", () => {
+    const events = anthropicMessagesToEvents([
+      { role: "user", content: "Hello" },
+      { role: "assistant", content: "Hi there" },
+    ]);
+    expect(events[0].kind).toBe("plan");
+    expect(events[1].kind).toBe("run");
+    expect(events[1].output).toBe("Hi there");
+  });
+
+  it("normalizes Vercel AI SDK streams", () => {
+    const events = vercelAiMessagesToEvents([
+      { type: "message", role: "assistant", content: "Done" },
+      { type: "tool", role: "tool", content: "result" },
+    ]);
+    expect(events[0].meta?.provider).toBe("vercel-ai");
+    expect(events[1].kind).toBe("tool");
+  });
+
+  it("normalizes LangChain run traces", () => {
+    const events = langChainRunsToEvents({
+      id: "run-1",
+      name: "planner",
+      type: "chain",
+      inputs: { question: "Q" },
+      outputs: { answer: "A" },
+    });
+    expect(events[0].id).toBe("run-1");
+    expect(events[0].kind).toBe("run");
+  });
+
+  it("normalizes MCP events", () => {
+    const events = mcpEventsToRunEvents([
+      { type: "message", message: "Working" },
+      { type: "error", error: { message: "Failed" } },
+    ]);
+    expect(events[0].kind).toBe("log");
+    expect(events[1].kind).toBe("error");
+  });
+});

--- a/packages/speckit-core/package.json
+++ b/packages/speckit-core/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@speckit/core",
+  "version": "0.0.1",
+  "type": "module",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./sanitizer": {
+      "types": "./dist/sanitizer.d.ts",
+      "import": "./dist/sanitizer.mjs",
+      "require": "./dist/sanitizer.cjs"
+    },
+    "./metrics": {
+      "types": "./dist/metrics.d.ts",
+      "import": "./dist/metrics.mjs",
+      "require": "./dist/metrics.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
+  "scripts": {
+    "build": "tsup src/index.ts src/sanitizer.ts src/metrics.ts --format esm,cjs --dts --clean --target es2022",
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@speckit/analyzer": "workspace:*"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.1",
+    "typescript": "^5.6.2",
+    "vitest": "^3.2.4"
+  }
+}

--- a/packages/speckit-core/patterns/sanitizer-patterns.json
+++ b/packages/speckit-core/patterns/sanitizer-patterns.json
@@ -1,0 +1,13 @@
+[
+  { "pattern": "sk-[a-zA-Z0-9]{20,}", "flags": "gi", "replacement": "[redacted-token]" },
+  { "pattern": "gh[pous]_[a-zA-Z0-9]{20,}", "flags": "gi", "replacement": "[redacted-token]" },
+  { "pattern": "eyJ[0-9a-zA-Z_-]{10,}\\.[0-9a-zA-Z_-]{10,}\\.[0-9a-zA-Z_-]{10,}", "flags": "g", "replacement": "[redacted-jwt]" },
+  { "pattern": "xox[baprs]-[0-9A-Za-z-]{10,}", "flags": "g", "replacement": "[redacted-slack-token]" },
+  { "pattern": "AKIA[0-9A-Z]{16}", "flags": "g", "replacement": "[redacted-aws-key]" },
+  { "pattern": "AIza[0-9A-Za-z_-]{35}", "flags": "g", "replacement": "[redacted-google-key]" },
+  { "pattern": "(sessionid=)[^;\\s]+", "flags": "gi", "replacement": "$1[redacted]" },
+  { "pattern": "(cookie:)\\s*[^\\n]+", "flags": "gi", "replacement": "$1 [redacted-cookie]" },
+  { "pattern": "https?:\\/\\/[^\\s:@]+:[^@\\s]+@", "flags": "g", "replacement": "[redacted-url]" },
+  { "pattern": "-----BEGIN [^-]+-----[\\s\\S]+?-----END [^-]+-----", "flags": "g", "replacement": "[redacted-key-block]" },
+  { "pattern": "ssh-(rsa|ed25519) [A-Za-z0-9+/=]{100,}", "flags": "g", "replacement": "[redacted-ssh-key]" }
+]

--- a/packages/speckit-core/src/index.ts
+++ b/packages/speckit-core/src/index.ts
@@ -1,0 +1,70 @@
+import { analyze, type AnalyzerResult, type AnalyzeOptions, type FailureRule, type LogSourceInput } from "@speckit/analyzer";
+import { createFileLogSource, loadFailureRulesFromFs } from "@speckit/analyzer/adapters/node";
+
+export type { AnalyzerResult } from "@speckit/analyzer";
+export type { MetricRow, MetricsSummaryOptions } from "./metrics.js";
+export type {
+  SanitizeLogsInput,
+  SanitizeLogsOptions,
+  SanitizeLogsResult,
+  SanitizeTextResult,
+  SanitizerPatternDefinition,
+} from "./sanitizer.js";
+
+export { metrics } from "./metrics.js";
+export {
+  sanitizeLogs,
+  sanitizeText,
+  defaultSanitizerPatterns,
+  defaultSanitizerPatternSources,
+} from "./sanitizer.js";
+
+export interface AnalyzeLogsOptions {
+  files?: string[];
+  sources?: Iterable<LogSourceInput> | AsyncIterable<LogSourceInput>;
+  runId?: AnalyzeOptions["runId"];
+  prompt?: AnalyzeOptions["prompt"];
+  metadata?: AnalyzeOptions["metadata"];
+  rules?: FailureRule[];
+  failureRulesRoot?: string;
+  failureRulesOutDir?: string;
+}
+
+async function resolveSources(options: AnalyzeLogsOptions): Promise<Iterable<LogSourceInput> | AsyncIterable<LogSourceInput>> {
+  if (options.sources) {
+    return options.sources;
+  }
+  if (options.files && options.files.length > 0) {
+    const sources = await Promise.all(options.files.map(file => createFileLogSource(file)));
+    return sources;
+  }
+  throw new Error("analyzeLogs requires either sources or files to be provided");
+}
+
+async function resolveFailureRules(options: AnalyzeLogsOptions): Promise<FailureRule[] | undefined> {
+  if (options.rules) {
+    return options.rules;
+  }
+  if (options.failureRulesRoot) {
+    const outDir = options.failureRulesOutDir ?? ".speckit";
+    try {
+      return await loadFailureRulesFromFs(options.failureRulesRoot, outDir);
+    } catch (error) {
+      const err = error as Error;
+      throw new Error(`Unable to load failure rules: ${err.message}`);
+    }
+  }
+  return undefined;
+}
+
+export async function analyzeLogs(options: AnalyzeLogsOptions): Promise<AnalyzerResult> {
+  const sources = await resolveSources(options);
+  const rules = await resolveFailureRules(options);
+  return analyze({
+    sources,
+    runId: options.runId,
+    prompt: options.prompt,
+    metadata: options.metadata,
+    rules,
+  });
+}

--- a/packages/speckit-core/src/metrics.ts
+++ b/packages/speckit-core/src/metrics.ts
@@ -1,0 +1,100 @@
+import type { AnalyzerResult, Metrics } from "@speckit/analyzer";
+
+export type MetricKey = keyof Metrics;
+
+export interface MetricRow {
+  key: MetricKey | "SanitizerHits";
+  label: string;
+  value: string;
+  raw: number | null;
+  target?: number | null;
+  met?: boolean | null;
+}
+
+export interface MetricsSummaryOptions {
+  decimals?: number;
+  targets?: Partial<Record<MetricKey, number>>;
+  sanitizerHits?: number | null;
+}
+
+const METRIC_LABELS: Record<MetricKey, string> = {
+  ReqCoverage: "Requirement Coverage",
+  BacktrackRatio: "Backtrack Ratio",
+  ToolPrecisionAt1: "Tool Precision @1",
+  EditLocality: "Edit Locality",
+  ReflectionDensity: "Reflection Density",
+  TTFPSeconds: "Time to First Patch (s)",
+};
+
+const DEFAULT_TARGETS: Partial<Record<MetricKey, number>> = {
+  ReqCoverage: 1,
+  ToolPrecisionAt1: 0.7,
+  BacktrackRatio: 0.2,
+  EditLocality: 0.75,
+  ReflectionDensity: 0.25,
+};
+
+function formatValue(value: number | null, decimals: number): string {
+  if (value === null || value === undefined) {
+    return "—";
+  }
+  if (!Number.isFinite(value)) {
+    return String(value);
+  }
+  return value.toFixed(decimals);
+}
+
+function evaluateMetric(key: MetricKey, value: number | null, target: number | null): boolean | null {
+  if (value === null || target === null || target === undefined) {
+    return null;
+  }
+  if (!Number.isFinite(value) || !Number.isFinite(target)) {
+    return null;
+  }
+  switch (key) {
+    case "BacktrackRatio":
+    case "ReflectionDensity":
+      return value <= target;
+    case "TTFPSeconds":
+      return value <= target;
+    default:
+      return value >= target;
+  }
+}
+
+export function metrics(
+  input: Metrics | AnalyzerResult,
+  options: MetricsSummaryOptions = {}
+): MetricRow[] {
+  const decimals = options.decimals ?? 2;
+  const rawMetrics: Metrics = "metrics" in input ? input.metrics : (input as Metrics);
+  const targets = { ...DEFAULT_TARGETS, ...(options.targets ?? {}) };
+
+  const rows: MetricRow[] = (Object.entries(METRIC_LABELS) as Array<[MetricKey, string]>).map(([key, label]) => {
+    const value = rawMetrics[key];
+    const target = key === "TTFPSeconds" ? (targets[key] ?? null) : targets[key] ?? null;
+    return {
+      key,
+      label,
+      raw: value ?? null,
+      value: formatValue(value ?? null, key === "TTFPSeconds" ? 1 : decimals),
+      target,
+      met: evaluateMetric(key, value ?? null, target ?? null),
+    };
+  });
+
+  if (options.sanitizerHits !== undefined && options.sanitizerHits !== null) {
+    rows.push({
+      key: "SanitizerHits",
+      label: "Sanitizer Hits",
+      raw: options.sanitizerHits,
+      value: options.sanitizerHits.toString(),
+      target: 0,
+      met: options.sanitizerHits === 0,
+    });
+  }
+
+  return rows;
+}
+
+export { METRIC_LABELS };

--- a/packages/speckit-core/src/sanitizer.ts
+++ b/packages/speckit-core/src/sanitizer.ts
@@ -1,0 +1,129 @@
+import rawPatterns from "../patterns/sanitizer-patterns.json";
+
+export interface SanitizerPatternDefinition {
+  pattern: string;
+  flags?: string;
+  replacement: string;
+}
+
+interface CompiledPattern {
+  definition: SanitizerPatternDefinition;
+  regex: RegExp;
+}
+
+export interface SanitizeTextResult {
+  redacted: string;
+  hits: number;
+  patternHits: Record<string, number>;
+}
+
+export interface SanitizeLogsInput {
+  id: string;
+  content: string;
+}
+
+export interface SanitizedLogEntry extends SanitizeLogsInput {
+  redacted: string;
+  hits: number;
+}
+
+export interface SanitizeLogsOptions {
+  patterns?: SanitizerPatternDefinition[];
+}
+
+export interface SanitizeLogsResult {
+  totalHits: number;
+  entries: SanitizedLogEntry[];
+  patternHits: Record<string, number>;
+}
+
+function ensureGlobalFlags(flags: string | undefined): string {
+  if (!flags) {
+    return "g";
+  }
+  return flags.includes("g") ? flags : `${flags}g`;
+}
+
+function compilePattern(definition: SanitizerPatternDefinition): CompiledPattern {
+  const flags = ensureGlobalFlags(definition.flags);
+  return {
+    definition,
+    regex: new RegExp(definition.pattern, flags),
+  };
+}
+
+const DEFAULT_PATTERN_DEFINITIONS = (rawPatterns as SanitizerPatternDefinition[]).map(pattern => ({
+  pattern: pattern.pattern,
+  flags: pattern.flags,
+  replacement: pattern.replacement,
+}));
+
+const DEFAULT_PATTERNS = DEFAULT_PATTERN_DEFINITIONS.map(compilePattern);
+
+function applyPatterns(text: string, patterns: CompiledPattern[]): SanitizeTextResult {
+  let redacted = text;
+  let totalHits = 0;
+  const perPatternHits = new Map<string, number>();
+
+  for (const entry of patterns) {
+    const { regex, definition } = entry;
+    regex.lastIndex = 0;
+    const matches = redacted.match(regex);
+    if (!matches || matches.length === 0) {
+      continue;
+    }
+    totalHits += matches.length;
+    perPatternHits.set(definition.pattern, (perPatternHits.get(definition.pattern) ?? 0) + matches.length);
+    regex.lastIndex = 0;
+    redacted = redacted.replace(regex, definition.replacement);
+    regex.lastIndex = 0;
+  }
+
+  return {
+    redacted,
+    hits: totalHits,
+    patternHits: Object.fromEntries(perPatternHits.entries()),
+  };
+}
+
+export function sanitizeText(
+  text: string,
+  options: SanitizeLogsOptions = {}
+): SanitizeTextResult {
+  const patterns = (options.patterns ?? DEFAULT_PATTERN_DEFINITIONS).map(compilePattern);
+  return applyPatterns(text, patterns);
+}
+
+export function sanitizeLogs(
+  inputs: Iterable<SanitizeLogsInput>,
+  options: SanitizeLogsOptions = {}
+): SanitizeLogsResult {
+  const patternDefinitions = options.patterns ?? DEFAULT_PATTERN_DEFINITIONS;
+  const compiled = patternDefinitions.map(compilePattern);
+  let totalHits = 0;
+  const aggregatedPatternHits = new Map<string, number>();
+  const entries: SanitizedLogEntry[] = [];
+
+  for (const input of inputs) {
+    const { redacted, hits, patternHits } = applyPatterns(input.content, compiled);
+    totalHits += hits;
+    for (const [pattern, count] of Object.entries(patternHits)) {
+      aggregatedPatternHits.set(pattern, (aggregatedPatternHits.get(pattern) ?? 0) + count);
+    }
+    entries.push({ id: input.id, content: input.content, redacted, hits });
+  }
+
+  return {
+    totalHits,
+    entries,
+    patternHits: Object.fromEntries(aggregatedPatternHits.entries()),
+  };
+}
+
+export function defaultSanitizerPatterns(): SanitizerPatternDefinition[] {
+  return DEFAULT_PATTERN_DEFINITIONS.map(pattern => ({ ...pattern }));
+}
+
+export function defaultSanitizerPatternSources(): string[] {
+  return DEFAULT_PATTERNS.map(pattern => pattern.regex.source);
+}

--- a/packages/speckit-core/test/analyzeLogs.test.ts
+++ b/packages/speckit-core/test/analyzeLogs.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { analyzeLogs } from "../src/index.js";
+
+const analyzeMock = vi.hoisted(() =>
+  vi.fn(async () => ({
+    run: {
+      runId: "mock-run",
+      sourceLogs: ["log.ndjson"],
+      startedAt: null,
+      finishedAt: null,
+      events: [],
+    },
+    requirements: [],
+    metrics: {
+      ReqCoverage: 1,
+      BacktrackRatio: 0,
+      ToolPrecisionAt1: 1,
+      EditLocality: 1,
+      ReflectionDensity: 0,
+      TTFPSeconds: null,
+    },
+    labels: new Set<string>(),
+    normalized: { events: [], promptCandidates: [], plainText: "" },
+    hints: ["Capture logs"],
+    prompt: "",
+  }))
+);
+
+vi.mock("@speckit/analyzer", () => ({
+  analyze: analyzeMock,
+}));
+
+vi.mock("@speckit/analyzer/adapters/node", () => ({
+  createFileLogSource: vi.fn(async (file: string) => ({ id: file, content: "" })),
+  loadFailureRulesFromFs: vi.fn(async () => []),
+}));
+
+describe("analyzeLogs", () => {
+  beforeEach(() => {
+    analyzeMock.mockClear();
+  });
+
+  it("passes arguments through to the analyzer", async () => {
+    const result = await analyzeLogs({ files: ["log.ndjson"], runId: "test-run" });
+    expect(analyzeMock).toHaveBeenCalled();
+    expect(result.run.runId).toBe("mock-run");
+    expect(result.metrics.ReqCoverage).toBe(1);
+  });
+});

--- a/packages/speckit-core/test/metrics.test.ts
+++ b/packages/speckit-core/test/metrics.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+
+import { metrics } from "../src/metrics.js";
+
+const SAMPLE_METRICS = {
+  ReqCoverage: 0.9,
+  BacktrackRatio: 0.1,
+  ToolPrecisionAt1: 0.8,
+  EditLocality: 0.85,
+  ReflectionDensity: 0.15,
+  TTFPSeconds: 42,
+} as const;
+
+describe("metrics", () => {
+  it("produces formatted rows with thresholds", () => {
+    const rows = metrics(SAMPLE_METRICS, { sanitizerHits: 0 });
+    const coverage = rows.find(row => row.key === "ReqCoverage");
+    expect(coverage?.label).toBe("Requirement Coverage");
+    expect(coverage?.value).toBe("0.90");
+    const sanitizer = rows.find(row => row.key === "SanitizerHits");
+    expect(sanitizer?.value).toBe("0");
+    expect(sanitizer?.met).toBe(true);
+  });
+});

--- a/packages/speckit-core/test/sanitizer.test.ts
+++ b/packages/speckit-core/test/sanitizer.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  sanitizeLogs,
+  sanitizeText,
+  defaultSanitizerPatternSources,
+} from "../src/sanitizer.js";
+
+describe("sanitizeText", () => {
+  it("redacts known API tokens and counts hits", () => {
+    const sample = "sk-abc1234567890123456789 is secret";
+    const { redacted, hits } = sanitizeText(sample);
+    expect(redacted).toContain("[redacted-token]");
+    expect(redacted).not.toContain("sk-abc");
+    expect(hits).toBeGreaterThan(0);
+  });
+
+  it("redacts multi-line key blocks", () => {
+    const sample = `-----BEGIN PRIVATE KEY-----\nabc123\n-----END PRIVATE KEY-----`;
+    const { redacted, hits } = sanitizeText(sample);
+    expect(redacted.trim()).toBe("[redacted-key-block]");
+    expect(hits).toBe(1);
+  });
+});
+
+describe("sanitizeLogs", () => {
+  it("aggregates hits across entries", () => {
+    const logs = [
+      { id: "a", content: "sessionid=abc" },
+      { id: "b", content: "cookie: secret-token" },
+    ];
+    const result = sanitizeLogs(logs);
+    expect(result.totalHits).toBeGreaterThanOrEqual(2);
+    expect(result.entries[0].redacted).toContain("[redacted]");
+    expect(result.entries[1].redacted).toContain("[redacted-cookie]");
+    expect(Object.keys(result.patternHits).length).toBeGreaterThan(0);
+  });
+});
+
+describe("defaultSanitizerPatternSources", () => {
+  it("exposes the compiled regular expressions for downstream use", () => {
+    const sources = defaultSanitizerPatternSources();
+    expect(sources.some(source => source.includes("sk-"))).toBe(true);
+  });
+});

--- a/packages/speckit-core/tsconfig.json
+++ b/packages/speckit-core/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": "..",
+    "resolveJsonModule": true
+  },
+  "include": ["src"]
+}

--- a/packages/speckit-core/vitest.config.ts
+++ b/packages/speckit-core/vitest.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const PACKAGE_DIR = path.dirname(fileURLToPath(new URL(".", import.meta.url)));
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    coverage: {
+      reporter: ["text", "lcov"],
+    },
+  },
+  resolve: {
+    alias: [
+      {
+        find: /^@speckit\/analyzer$/,
+        replacement: path.resolve(PACKAGE_DIR, "../speckit-analyzer/src/index.ts"),
+      },
+      {
+        find: /^@speckit\/analyzer\/(.*)$/,
+        replacement: path.resolve(PACKAGE_DIR, "../speckit-analyzer/src/$1"),
+      },
+    ],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@types/node':
         specifier: ^24.5.2
         version: 24.5.2
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -340,6 +346,22 @@ importers:
       typescript:
         specifier: ^5.6.2
         version: 5.9.2
+
+  packages/speckit-core:
+    dependencies:
+      '@speckit/analyzer':
+        specifier: workspace:*
+        version: link:../speckit-analyzer
+    devDependencies:
+      tsup:
+        specifier: ^8.0.1
+        version: 8.5.0(jiti@2.6.0)(postcss@8.5.6)(tsx@4.20.6)(typescript@5.9.2)(yaml@2.8.1)
+      typescript:
+        specifier: ^5.6.2
+        version: 5.9.2
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.5.2)(jiti@2.6.0)(terser@5.44.0)(tsx@4.20.6)(yaml@2.8.1)
 
   packages/speckit-engine:
     dependencies:
@@ -2901,6 +2923,14 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -10636,6 +10666,10 @@ snapshots:
       zod: 4.1.11
 
   ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 

--- a/policy/badges/feature-graduated.svg
+++ b/policy/badges/feature-graduated.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="170" height="30" role="img" aria-label="Feature: graduated">
+  <linearGradient id="a" x2="0" y2="100%">
+    <stop offset="0" stop-color="#fff" stop-opacity=".7"/>
+    <stop offset="1" stop-opacity=".7"/>
+  </linearGradient>
+  <rect rx="4" width="170" height="30" fill="#0b1f2a"/>
+  <rect rx="4" x="68" width="102" height="30" fill="#1f7a53"/>
+  <rect rx="4" width="170" height="30" fill="url(#a)"/>
+  <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="14">
+    <text x="34" y="20">Feature</text>
+    <text x="118" y="20">graduated</text>
+  </g>
+</svg>

--- a/policy/feature-graduation.md
+++ b/policy/feature-graduation.md
@@ -1,0 +1,18 @@
+# Feature Graduation Policy
+
+SpecKit features move from **experimental** to **graduated** when they meet the following gates:
+
+1. **Validation** – automated schema checks pass (`pnpm speckit:validate-artifacts`) and feature-specific smoke tests run in CI.
+2. **Documentation** – RTM and `.speckit/summary.md` call out the capability, including hints for the next agent run.
+3. **Adoption Signal** – at least two internal projects have adopted the feature with no open severity-one defects for two sprints.
+4. **Support Plan** – a rollback/mitigation path is documented in `docs/internal/specs/speckit-spec.md`.
+
+When a feature graduates, add the `feature-graduated` badge to the README section describing the capability.
+
+![Feature graduated badge](badges/feature-graduated.svg)
+
+For each graduation decision, create or update a decision record (see ADR 0003) and link to the supporting artifacts:
+
+- The `.speckit/summary.json` generated for the run that achieved the exit criteria.
+- CI logs demonstrating schema validation success.
+- A pull request or doc that records the support plan.

--- a/schemas/metrics.v1.schema.json
+++ b/schemas/metrics.v1.schema.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SpecKit metrics artifact v1",
+  "type": "object",
+  "required": [
+    "version",
+    "ReqCoverage",
+    "ToolPrecisionAt1",
+    "BacktrackRatio",
+    "EditLocality",
+    "ReflectionDensity",
+    "TTFPSeconds",
+    "labels",
+    "sanitizer_hits",
+    "experiments"
+  ],
+  "properties": {
+    "version": { "type": "integer", "const": 1 },
+    "ReqCoverage": { "type": "number", "minimum": 0 },
+    "ToolPrecisionAt1": { "type": "number", "minimum": 0 },
+    "BacktrackRatio": { "type": "number", "minimum": 0 },
+    "EditLocality": { "type": "number", "minimum": 0 },
+    "ReflectionDensity": { "type": "number", "minimum": 0 },
+    "TTFPSeconds": { "type": ["number", "null"], "minimum": 0 },
+    "labels": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "sanitizer_hits": { "type": "integer", "minimum": 0 },
+    "experiments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["key", "variant", "bucket", "metadata"],
+        "properties": {
+          "key": { "type": "string", "minLength": 1 },
+          "description": { "type": ["string", "null"], "minLength": 1 },
+          "variant": { "type": "string", "minLength": 1 },
+          "variant_description": { "type": ["string", "null"], "minLength": 1 },
+          "bucket": { "type": "number" },
+          "metadata": { "type": "object" }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/requirements.v1.schema.json
+++ b/schemas/requirements.v1.schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SpecKit requirements record v1",
+  "type": "object",
+  "required": ["id", "text", "status", "evidence"],
+  "properties": {
+    "id": { "type": "string", "minLength": 1 },
+    "text": { "type": "string", "minLength": 1 },
+    "source": { "type": ["string", "null"], "minLength": 1 },
+    "category": { "type": ["string", "null"], "minLength": 1 },
+    "constraints": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "status": {
+      "type": "string",
+      "enum": ["unknown", "satisfied", "violated", "in-progress"]
+    },
+    "evidence": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "notes": { "type": ["string", "null"], "minLength": 1 }
+  },
+  "additionalProperties": false
+}

--- a/schemas/summary.v1.schema.json
+++ b/schemas/summary.v1.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "SpecKit summary artifact v1",
+  "type": "object",
+  "required": [
+    "version",
+    "generated_at",
+    "run",
+    "metrics",
+    "labels",
+    "requirements",
+    "hints",
+    "artifacts"
+  ],
+  "properties": {
+    "version": { "type": "integer", "const": 1 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "run": {
+      "type": "object",
+      "required": ["id", "sources", "events"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "sources": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "events": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": false
+    },
+    "metrics": {
+      "type": "object",
+      "required": [
+        "ReqCoverage",
+        "ToolPrecisionAt1",
+        "BacktrackRatio",
+        "EditLocality",
+        "ReflectionDensity",
+        "TTFPSeconds",
+        "sanitizer_hits"
+      ],
+      "properties": {
+        "ReqCoverage": { "type": "number" },
+        "ToolPrecisionAt1": { "type": "number" },
+        "BacktrackRatio": { "type": "number" },
+        "EditLocality": { "type": "number" },
+        "ReflectionDensity": { "type": "number" },
+        "TTFPSeconds": { "type": ["number", "null"] },
+        "sanitizer_hits": { "type": "integer", "minimum": 0 }
+      },
+      "additionalProperties": true
+    },
+    "labels": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "requirements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "status", "text", "evidence"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "minLength": 1 },
+          "text": { "type": "string", "minLength": 1 },
+          "evidence": {
+            "type": "array",
+            "items": { "type": "string", "minLength": 1 }
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "hints": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "artifacts": {
+      "type": "object",
+      "required": [
+        "run",
+        "requirements",
+        "metrics",
+        "summary",
+        "summary_json",
+        "memo",
+        "verification"
+      ],
+      "properties": {
+        "run": { "type": "string", "minLength": 1 },
+        "requirements": { "type": "string", "minLength": 1 },
+        "metrics": { "type": "string", "minLength": 1 },
+        "summary": { "type": "string", "minLength": 1 },
+        "summary_json": { "type": "string", "minLength": 1 },
+        "memo": { "type": "string", "minLength": 1 },
+        "verification": { "type": "string", "minLength": 1 }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/scripts/run-analysis.ts
+++ b/scripts/run-analysis.ts
@@ -23,6 +23,7 @@ export interface RunAnalysisResult {
   normalized: NormalizedLog;
   artifacts: Awaited<ReturnType<typeof writeArtifacts>>;
   experiments: ExperimentAssignment[];
+  hints: string[];
 }
 
 export interface RunAnalysisOptions {
@@ -112,7 +113,7 @@ async function readSanitizerHits(outDir: string, rootDir: string): Promise<numbe
   }
 }
 
-type AnalyzerArtifactsInput = Pick<AnalyzerResult, "run" | "requirements" | "metrics" | "labels"> & {
+type AnalyzerArtifactsInput = Pick<AnalyzerResult, "run" | "requirements" | "metrics" | "labels" | "hints"> & {
   rootDir: string;
   outDir: string;
   experiments: ExperimentAssignment[];
@@ -131,6 +132,7 @@ export async function emitAnalyzerArtifacts(
     labels: options.labels,
     sanitizerHits,
     experiments: options.experiments,
+    hints: options.hints,
   });
 }
 
@@ -175,6 +177,7 @@ export async function runAnalysis(
     requirements: analysis.requirements,
     metrics: analysis.metrics,
     labels: analysis.labels,
+    hints: analysis.hints,
     experiments,
   });
   await updateRTM({ rootDir: context.rootDir, outDir: resolvedOutDir, rtmPath: undefined });
@@ -186,5 +189,6 @@ export async function runAnalysis(
     normalized: analysis.normalized,
     artifacts,
     experiments,
+    hints: analysis.hints,
   };
 }

--- a/scripts/utils/redact.ts
+++ b/scripts/utils/redact.ts
@@ -1,26 +1,21 @@
-const SECRET_PATTERNS: { pattern: RegExp; replacement: string }[] = [
-  { pattern: /(sk-[a-z0-9]{20,})/gi, replacement: "[redacted-token]" },
-  { pattern: /(gh[pous]_[a-z0-9]{20,})/gi, replacement: "[redacted-token]" },
-  { pattern: /(eyJ[0-9a-zA-Z_-]{10,}\.[0-9a-zA-Z_-]{10,}\.[0-9a-zA-Z_-]{10,})/g, replacement: "[redacted-jwt]" },
-  { pattern: /(sessionid=)[^;\s]+/gi, replacement: "$1[redacted]" },
-  { pattern: /(cookie:)[^\n]+/gi, replacement: "$1 [redacted-cookie]" },
-  { pattern: /(https?:\/\/[^\s]+:[^@\s]+@)/gi, replacement: "[redacted-url]" },
-];
+import {
+  defaultSanitizerPatterns,
+  defaultSanitizerPatternSources,
+  sanitizeText,
+} from "@speckit/core/sanitizer";
+
+const SECRET_PATTERNS = defaultSanitizerPatterns().map(({ pattern, flags }) => new RegExp(pattern, flags));
 
 export function redactSecrets(text: string): { redacted: string; hits: number } {
-  let hits = 0;
-  let redacted = text;
-  for (const { pattern, replacement } of SECRET_PATTERNS) {
-    if (pattern.test(redacted)) {
-      hits += (redacted.match(pattern) ?? []).length;
-      redacted = redacted.replace(pattern, replacement);
-    }
-  }
+  const { redacted, hits } = sanitizeText(text);
   return { redacted, hits };
 }
 
 export function containsSecrets(text: string): boolean {
-  return SECRET_PATTERNS.some(({ pattern }) => pattern.test(text));
+  return SECRET_PATTERNS.some(pattern => {
+    pattern.lastIndex = 0;
+    return pattern.test(text);
+  });
 }
 
-export const sanitizerPatterns = SECRET_PATTERNS.map(({ pattern }) => pattern.source);
+export const sanitizerPatterns = defaultSanitizerPatternSources();

--- a/scripts/validators/validate-artifacts.ts
+++ b/scripts/validators/validate-artifacts.ts
@@ -1,0 +1,135 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import Ajv2020 from "ajv/dist/2020";
+import addFormats from "ajv-formats";
+
+interface ValidationResult {
+  file: string;
+  ok: boolean;
+  errors: string[];
+}
+
+const ROOT = process.cwd();
+const SPECKIT_DIR = path.join(ROOT, ".speckit");
+const SCHEMA_DIR = path.join(ROOT, "schemas");
+
+async function readJson(filePath: string): Promise<unknown> {
+  const raw = await fs.readFile(filePath, "utf8");
+  return JSON.parse(raw) as unknown;
+}
+
+async function validateJsonFile(
+  ajv: Ajv,
+  filePath: string,
+  schemaPath: string,
+  description: string
+): Promise<ValidationResult> {
+  try {
+    const data = await readJson(filePath);
+    const schema = await readJson(schemaPath);
+    const validate = ajv.compile(schema);
+    const ok = validate(data);
+    const errors = ok ? [] : (validate.errors ?? []).map((error) => `${error.instancePath || "/"} ${error.message ?? "invalid"}`);
+    return { file: description, ok: Boolean(ok), errors };
+  } catch (error) {
+    const err = error as Error & { code?: string };
+    if (err.code === "ENOENT") {
+      return { file: description, ok: false, errors: ["file not found"] };
+    }
+    return { file: description, ok: false, errors: [err.message] };
+  }
+}
+
+async function validateJsonlFile(
+  ajv: Ajv,
+  filePath: string,
+  schemaPath: string,
+  description: string
+): Promise<ValidationResult> {
+  try {
+    const raw = await fs.readFile(filePath, "utf8");
+    const schema = await readJson(schemaPath);
+    const validate = ajv.compile(schema);
+    const errors: string[] = [];
+    const lines = raw.split(/\r?\n/).filter((line) => line.trim().length > 0);
+    for (let index = 0; index < lines.length; index += 1) {
+      const line = lines[index];
+      try {
+        const parsed = JSON.parse(line) as unknown;
+        const ok = validate(parsed);
+        if (!ok) {
+          const details = (validate.errors ?? [])
+            .map((error) => `${error.instancePath || "/"} ${error.message ?? "invalid"}`)
+            .join(", ");
+          errors.push(`line ${index + 1}: ${details}`);
+        }
+      } catch (error) {
+        errors.push(`line ${index + 1}: ${(error as Error).message}`);
+      }
+    }
+    return { file: description, ok: errors.length === 0, errors };
+  } catch (error) {
+    const err = error as Error & { code?: string };
+    if (err.code === "ENOENT") {
+      return { file: description, ok: false, errors: ["file not found"] };
+    }
+    return { file: description, ok: false, errors: [err.message] };
+  }
+}
+
+async function main(): Promise<void> {
+  const ajv = new Ajv2020({ allErrors: true, strict: false });
+  addFormats(ajv);
+  const results: ValidationResult[] = [];
+
+  results.push(
+    await validateJsonFile(
+      ajv,
+      path.join(SPECKIT_DIR, "metrics.json"),
+      path.join(SCHEMA_DIR, "metrics.v1.schema.json"),
+      "metrics.json"
+    )
+  );
+
+  results.push(
+    await validateJsonFile(
+      ajv,
+      path.join(SPECKIT_DIR, "summary.json"),
+      path.join(SCHEMA_DIR, "summary.v1.schema.json"),
+      "summary.json"
+    )
+  );
+
+  results.push(
+    await validateJsonlFile(
+      ajv,
+      path.join(SPECKIT_DIR, "requirements.jsonl"),
+      path.join(SCHEMA_DIR, "requirements.v1.schema.json"),
+      "requirements.jsonl"
+    )
+  );
+
+  let ok = true;
+  for (const result of results) {
+    if (result.ok) {
+      console.log(`✅ ${result.file}`);
+    } else {
+      ok = false;
+      console.error(`❌ ${result.file}`);
+      for (const error of result.errors) {
+        console.error(`   - ${error}`);
+      }
+    }
+  }
+
+  if (!ok) {
+    process.exitCode = 1;
+    throw new Error("Artifact schema validation failed");
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exit(1);
+});

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -24,7 +24,9 @@
       "@speckit/tui": ["packages/speckit-tui/src/index.tsx"],
       "@speckit/cli": ["packages/speckit-cli/src/index.ts"],
       "@speckit/adapter-speckit-v1": ["packages/adapter-speckit-v1/src/index.ts"],
-      "@speckit/adapter-owasp-asvs-v4": ["packages/adapter-owasp-asvs-v4/src/index.ts"]
+      "@speckit/adapter-owasp-asvs-v4": ["packages/adapter-owasp-asvs-v4/src/index.ts"],
+      "@speckit/core": ["packages/speckit-core/src/index.ts"],
+      "@speckit/core/*": ["packages/speckit-core/src/*"]
     }
   }
 }


### PR DESCRIPTION
* add `@speckit/core` package exposing `analyzeLogs`, `sanitizeLogs`, and metric helpers for downstream consumers (`packages/speckit-core/*`)
* wire analyzer provider adapters for OpenAI, Anthropic, Vercel AI SDK, LangChain/LangGraph, and MCP with coverage (`packages/speckit-analyzer/src/adapters/providers.ts`, `packages/speckit-analyzer/test/providers.test.ts`, run `pnpm --filter @speckit/analyzer test`)
* expand sanitizer patterns, reuse shared JSON, and update upload workflow/CLI integrations (`packages/speckit-core/patterns/sanitizer-patterns.json`, `.github/workflows/speckit-upload-logs.yml`, `scripts/utils/redact.ts`, run `pnpm --filter @speckit/core test`)
* generate `.speckit/summary.json`, add JSON schemas, and introduce CI validator (`schemas/*.json`, `scripts/validators/validate-artifacts.ts`, `scripts/writers/artifacts.ts`, run `pnpm speckit:validate-artifacts`)
* document outcomes via meta report plus feature graduation policy & badge (`.speckit/meta-sanity-report.md`, `policy/feature-graduation.md`, `docs/internal/adr/0003-feature-graduation-badge.md`)


------
https://chatgpt.com/codex/tasks/task_e_68d82a64e664832497dee062a1bb3eb4