### PR TITLE
speckit — repair analyze/upload workflows (robust multiline)

### DIFF
--- a/.github/workflows/speckit-analyze-run.yml
+++ b/.github/workflows/speckit-analyze-run.yml
@@ -42,9 +42,14 @@ jobs:
         id: check_logs
         run: |
           if [ -f agent-run-logs/agent-run-logs.tar.gz ]; then
-            echo "found=true" >> "$GITHUB_OUTPUT"
+            printf 'found=true\n' >> "$GITHUB_OUTPUT"
+            echo "speckit-analyze-run: agent-run-logs.tar.gz detected."
           else
-            echo "found=false" >> "$GITHUB_OUTPUT"
+            {
+              printf 'found=false\n'
+              printf 'log_count=0\n'
+            } >> "$GITHUB_OUTPUT"
+            echo "speckit-analyze-run: no log bundle found in artifacts."
           fi
 
       - name: Extract logs
@@ -56,8 +61,22 @@ jobs:
             echo "Sanitizer report detected." >> "$GITHUB_STEP_SUMMARY"
           fi
 
-      - name: Run analyzer
+      - name: Inventory extracted logs
         if: steps.check_logs.outputs.found == 'true'
+        id: log_inventory
+        run: |
+          if [ ! -d runs_from_artifact ]; then
+            printf 'log_count=0\n' >> "$GITHUB_OUTPUT"
+            echo "speckit-analyze-run: runs_from_artifact directory missing after extraction."
+            exit 0
+          fi
+
+          count=$(find runs_from_artifact -type f | wc -l | tr -d ' ')
+          printf 'log_count=%s\n' "$count" >> "$GITHUB_OUTPUT"
+          echo "speckit-analyze-run: detected ${count} extracted file(s)."
+
+      - name: Run analyzer
+        if: steps.check_logs.outputs.found == 'true' && steps.log_inventory.outputs.log_count != '0'
         run: |
           if [ -f runs_from_artifact/sanitizer-report.json ]; then
             mkdir -p .speckit
@@ -70,7 +89,7 @@ jobs:
             --raw-log "runs_from_artifact/**/*.ndjson"
 
       - name: Merge sanitizer report
-        if: steps.check_logs.outputs.found == 'true'
+        if: steps.check_logs.outputs.found == 'true' && steps.log_inventory.outputs.log_count != '0'
         run: |
           node <<'NODE'
           const fs = require('fs');
@@ -86,11 +105,11 @@ jobs:
           NODE
 
       - name: Update agent trends dashboard
-        if: steps.check_logs.outputs.found == 'true'
+        if: steps.check_logs.outputs.found == 'true' && steps.log_inventory.outputs.log_count != '0'
         run: pnpm tsx scripts/analytics/trends.ts
 
       - name: Commit run artifacts
-        if: steps.check_logs.outputs.found == 'true'
+        if: steps.check_logs.outputs.found == 'true' && steps.log_inventory.outputs.log_count != '0'
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore: update speckit run artifacts"
@@ -105,14 +124,20 @@ jobs:
             docs/internal/agents/coding-agent-brief.md
 
       - name: Write no-logs summary
-        if: steps.check_logs.outputs.found != 'true'
+        if: steps.check_logs.outputs.found != 'true' || steps.log_inventory.outputs.log_count == '0'
+        env:
+          LOG_COUNT: ${{ steps.log_inventory.outputs.log_count }}
+          FALLBACK_COUNT: ${{ steps.check_logs.outputs.log_count }}
         run: |
           mkdir -p .speckit
-          cat <<'EOF' > .speckit/summary.md
-# SpecKit Run Forensics
-
-No sanitized run logs were found for this pull request. Upload a runs/ bundle to enable automated analysis.
-EOF
+          count="${LOG_COUNT:-${FALLBACK_COUNT:-0}}"
+          printf '%s\n' \
+            '# SpecKit Run Forensics' \
+            '' \
+            'No sanitized run logs were found for this pull request.' \
+            "Detected log files: ${count}." \
+            'Upload a runs/ bundle to enable automated analysis.' \
+            > .speckit/summary.md
 
       - name: Post run summary comment
         uses: marocchino/sticky-pull-request-comment@v2

--- a/.github/workflows/speckit-upload-logs.yml
+++ b/.github/workflows/speckit-upload-logs.yml
@@ -19,11 +19,20 @@ jobs:
       - name: Detect run logs
         id: detect
         run: |
-          if compgen -G "runs/**/*" > /dev/null; then
-            echo "has_logs=true" >> "$GITHUB_OUTPUT"
+          if [ -d runs ]; then
+            count=$(find runs -type f | wc -l | tr -d ' ')
           else
-            echo "has_logs=false" >> "$GITHUB_OUTPUT"
+            count=0
           fi
+
+          if [ "$count" -gt 0 ]; then
+            printf 'has_logs=true\n' >> "$GITHUB_OUTPUT"
+          else
+            printf 'has_logs=false\n' >> "$GITHUB_OUTPUT"
+          fi
+
+          printf 'log_count=%s\n' "$count" >> "$GITHUB_OUTPUT"
+          echo "speckit-upload-logs: detected ${count} run file(s)."
 
       - name: Sanitize logs
         if: steps.detect.outputs.has_logs == 'true'
@@ -105,4 +114,8 @@ jobs:
 
       - name: No logs warning
         if: steps.detect.outputs.has_logs != 'true'
-        run: echo "speckit-upload-logs: no runs/ logs found. Upload skipped."
+        env:
+          LOG_COUNT: ${{ steps.detect.outputs.log_count }}
+        run: |
+          count="${LOG_COUNT:-0}"
+          echo "speckit-upload-logs: no runs/ logs found (detected ${count} file(s)). Upload skipped."


### PR DESCRIPTION
## Summary
- harden the analyze workflow log detection with reliable $GITHUB_OUTPUT writes and a log inventory step before processing
- replace the summary heredoc with printf-based block scalar output and surface detected log counts in the fallback summary
- report run log counts in the upload workflow, reuse them for messaging, and keep conditions resilient when no logs exist

## Testing
- `pnpm --filter @speckit/gen-tests test`


------
https://chatgpt.com/codex/tasks/task_e_68d82a6f75f4832480338bfe5347c089