### PR TITLE
feat: add schemas and CI validation for .speckit artifacts

### DIFF
--- a/.github/workflows/speckit-analyze-run.yml
+++ b/.github/workflows/speckit-analyze-run.yml
@@ -85,6 +85,10 @@ jobs:
           }
           NODE
 
+      - name: Validate artifacts
+        if: steps.check_logs.outputs.found == 'true'
+        run: pnpm speckit:validate-artifacts
+
       - name: Update agent trends dashboard
         if: steps.check_logs.outputs.found == 'true'
         run: pnpm tsx scripts/analytics/trends.ts

--- a/docs/internal/dev/artifacts.md
+++ b/docs/internal/dev/artifacts.md
@@ -1,0 +1,95 @@
+# SpecKit Artifact Schemas & Compatibility
+
+The `.speckit/` directory is the contract between the analyzer, CI, and any
+custom tooling layered on top of SpecKit. This note documents the JSON Schemas
+for the analyzer artifacts, how we version them, and how CI enforces
+compatibility.
+
+## Directory layout
+
+- `schemas/metrics.v1.schema.json` — canonical schema for `.speckit/metrics.json`.
+- `schemas/summary.v1.schema.json` — schema for the machine-readable run
+  summary (`.speckit/summary.json`).
+- `schemas/sanitizer-report.v1.schema.json` — schema for
+  `.speckit/sanitizer-report.json` produced by the redaction gate.
+
+Each schema file declares `draft/2020-12` to match the analyzer’s TypeScript
+modeling.
+
+## Versioning policy
+
+- Schemas are **append-only**. Breaking changes require a new file (e.g.,
+  `metrics.v2.schema.json`) and a coordinated change to the analyzer.
+- Backwards-compatible additions (new optional fields, relaxed enums) can ship in
+  the existing schema, but prefer a new version if consumers must opt in.
+- The analyzer artifacts carry their own `version` fields; bump them when
+  revving a schema so downstream tooling can react.
+
+## CI validation
+
+Use the helper to check local changes:
+
+```bash
+pnpm speckit:validate-artifacts
+```
+
+The `speckit-analyze-run` workflow runs a **Validate artifacts** step after the
+analyzer finishes. Any schema violation fails the job so incompatible writes are
+caught before merge.
+
+## Artifact reference
+
+### `.speckit/metrics.json` (v1)
+
+Flat metrics with experiment metadata:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `version` | `1` | Bump on breaking changes |
+| `ReqCoverage`, `ToolPrecisionAt1`, `BacktrackRatio`, `EditLocality`, `ReflectionDensity` | number | Normalized to `[0,1]` |
+| `TTFPSeconds` | number \| null | Seconds to first edit |
+| `labels` | string[] | Unique failure labels |
+| `sanitizer_hits` | number | Total redaction hits carried forward |
+| `experiments` | object[] | `{ key, variant, bucket, description?, variant_description?, metadata? }` |
+
+### `.speckit/summary.json` (v1)
+
+Machine-readable summary that feeds PR comments and dashboards:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `version` | `1` | Schema lock |
+| `generated_at` | RFC3339 string | Emission timestamp |
+| `run` | object | `{ id, sources[], events_analyzed }` |
+| `experiments` | object[] | Mirrors metrics experiments |
+| `metrics` | object[] | `{ label, value, threshold?, status? }` |
+| `labels` | string[] | Sorted failure labels |
+| `requirements` | object[] | `{ id, status, description }` |
+| `highlights` | object | Optional `{ lessons[], guardrails[] }` |
+
+### `.speckit/sanitizer-report.json` (v1)
+
+Redaction summary from the log sanitizer:
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `hits` | number | Required total matches |
+| `version` | number | Optional source version |
+| `generated_at` | RFC3339 string | Optional emission timestamp |
+| `entries` | object[] | Optional `{ rule_id, pattern?, hits, samples[] }` |
+| `entries[].samples[]` | object[] | `{ file, line, match }` snippets |
+
+`hits` must be non-negative; nested counts surface per-rule summaries for
+analytics.
+
+## Making changes safely
+
+1. Introduce new schema files for breaking changes and update the analyzer to
+   emit the matching `version`.
+2. Update this document and the compatibility policy with migration guidance.
+3. Run `pnpm speckit:validate-artifacts` before committing to ensure the new
+   artifacts conform locally.
+4. Verify CI’s **Validate artifacts** step succeeds in pull requests.
+
+This guardrail keeps SpecKit’s machine-readable artifacts stable for downstream
+integrations.

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "speckit:analyze": "tsx scripts/cli.ts analyze",
     "speckit:replay": "tsx scripts/cli.ts replay",
     "speckit:inject": "tsx scripts/cli.ts inject",
-    "speckit:trends": "tsx scripts/analytics/trends.ts"
+    "speckit:trends": "tsx scripts/analytics/trends.ts",
+    "speckit:validate-artifacts": "tsx scripts/validate-artifacts.ts"
   },
   "keywords": [
     "spec-driven-development",
@@ -46,6 +47,8 @@
     "@commitlint/cli": "^19.3.0",
     "@commitlint/config-conventional": "^19.3.0",
     "@types/node": "^24.5.2",
+    "ajv": "^8.17.1",
+    "ajv-formats": "^3.0.1",
     "chalk": "^5.3.0",
     "chokidar": "^3.6.0",
     "globby": "^14.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,12 @@ importers:
       '@types/node':
         specifier: ^24.5.2
         version: 24.5.2
+      ajv:
+        specifier: ^8.17.1
+        version: 8.17.1
+      ajv-formats:
+        specifier: ^3.0.1
+        version: 3.0.1(ajv@8.17.1)
       chalk:
         specifier: ^5.3.0
         version: 5.6.2
@@ -2901,6 +2907,14 @@ packages:
 
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
       ajv: ^8.0.0
     peerDependenciesMeta:
@@ -10636,6 +10650,10 @@ snapshots:
       zod: 4.1.11
 
   ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
+  ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
 

--- a/schemas/metrics.v1.schema.json
+++ b/schemas/metrics.v1.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://speckit.dev/schemas/metrics.v1.schema.json",
+  "title": "SpecKit metrics artifact (v1)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "version",
+    "ReqCoverage",
+    "ToolPrecisionAt1",
+    "BacktrackRatio",
+    "EditLocality",
+    "ReflectionDensity",
+    "TTFPSeconds",
+    "labels",
+    "sanitizer_hits",
+    "experiments"
+  ],
+  "properties": {
+    "version": { "type": "integer", "const": 1 },
+    "ReqCoverage": { "type": "number", "minimum": 0, "maximum": 1 },
+    "ToolPrecisionAt1": { "type": "number", "minimum": 0, "maximum": 1 },
+    "BacktrackRatio": { "type": "number", "minimum": 0, "maximum": 1 },
+    "EditLocality": { "type": "number", "minimum": 0, "maximum": 1 },
+    "ReflectionDensity": { "type": "number", "minimum": 0, "maximum": 1 },
+    "TTFPSeconds": { "type": ["number", "null"], "minimum": 0 },
+    "labels": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 },
+      "uniqueItems": true
+    },
+    "sanitizer_hits": { "type": "number", "minimum": 0 },
+    "experiments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key", "variant", "bucket"],
+        "properties": {
+          "key": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 },
+          "variant": { "type": "string", "minLength": 1 },
+          "variant_description": { "type": "string", "minLength": 1 },
+          "bucket": { "type": "integer", "minimum": 0 },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/schemas/sanitizer-report.v1.schema.json
+++ b/schemas/sanitizer-report.v1.schema.json
@@ -1,0 +1,39 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://speckit.dev/schemas/sanitizer-report.v1.schema.json",
+  "title": "SpecKit sanitizer report (v1)",
+  "type": "object",
+  "required": ["hits"],
+  "properties": {
+    "version": { "type": "integer", "minimum": 1 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "hits": { "type": "number", "minimum": 0 },
+    "entries": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["rule_id", "hits"],
+        "properties": {
+          "rule_id": { "type": "string", "minLength": 1 },
+          "pattern": { "type": "string", "minLength": 1 },
+          "hits": { "type": "number", "minimum": 0 },
+          "samples": {
+            "type": "array",
+            "items": {
+              "type": "object",
+              "additionalProperties": false,
+              "required": ["file", "line", "match"],
+              "properties": {
+                "file": { "type": "string", "minLength": 1 },
+                "line": { "type": "integer", "minimum": 1 },
+                "match": { "type": "string", "minLength": 1 }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": true
+}

--- a/schemas/summary.v1.schema.json
+++ b/schemas/summary.v1.schema.json
@@ -1,0 +1,98 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://speckit.dev/schemas/summary.v1.schema.json",
+  "title": "SpecKit summary artifact (v1)",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["version", "generated_at", "run", "metrics", "labels", "requirements"],
+  "properties": {
+    "version": { "type": "integer", "const": 1 },
+    "generated_at": { "type": "string", "format": "date-time" },
+    "run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "sources", "events_analyzed"],
+      "properties": {
+        "id": { "type": "string", "minLength": 1 },
+        "sources": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "events_analyzed": { "type": "integer", "minimum": 0 }
+      }
+    },
+    "experiments": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["key", "variant", "bucket"],
+        "properties": {
+          "key": { "type": "string", "minLength": 1 },
+          "description": { "type": "string", "minLength": 1 },
+          "variant": { "type": "string", "minLength": 1 },
+          "variant_description": { "type": "string", "minLength": 1 },
+          "bucket": { "type": "integer", "minimum": 0 },
+          "metadata": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        }
+      },
+      "default": []
+    },
+    "metrics": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["label", "value"],
+        "properties": {
+          "label": { "type": "string", "minLength": 1 },
+          "value": { "type": ["number", "null"] },
+          "threshold": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type", "value"],
+            "properties": {
+              "type": { "type": "string", "enum": ["min", "max"] },
+              "value": { "type": "number" }
+            }
+          },
+          "status": { "type": "string", "enum": ["ok", "warn", "fail"] }
+        }
+      }
+    },
+    "labels": {
+      "type": "array",
+      "items": { "type": "string", "minLength": 1 }
+    },
+    "requirements": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["id", "status", "description"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "status": { "type": "string", "enum": ["satisfied", "violated", "in-progress", "unknown"] },
+          "description": { "type": "string", "minLength": 1 }
+        }
+      }
+    },
+    "highlights": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "lessons": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "guardrails": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 }
+        }
+      }
+    }
+  }
+}

--- a/scripts/validate-artifacts.ts
+++ b/scripts/validate-artifacts.ts
@@ -1,0 +1,117 @@
+import { access, readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import Ajv, { type ErrorObject } from "ajv/dist/2020.js";
+import addFormats from "ajv-formats";
+
+interface ArtifactDefinition {
+  name: string;
+  schemaPath: string;
+  artifactPath: string;
+  optional?: boolean;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch (error) {
+    const nodeError = error as NodeJS.ErrnoException;
+    if (nodeError?.code === "ENOENT") {
+      return false;
+    }
+    throw error;
+  }
+}
+
+async function loadJson(filePath: string): Promise<unknown> {
+  const raw = await readFile(filePath, "utf8");
+  try {
+    return JSON.parse(raw);
+  } catch (error) {
+    throw new Error(`Failed to parse JSON at ${filePath}: ${(error as Error).message}`);
+  }
+}
+
+function formatErrors(errors: ErrorObject[] | null | undefined): string {
+  if (!errors || errors.length === 0) {
+    return "";
+  }
+  return errors
+    .map((error) => {
+      const dataPath = error.instancePath || "(root)";
+      return `  • ${dataPath} ${error.message ?? "validation error"}`;
+    })
+    .join("\n");
+}
+
+async function main(): Promise<void> {
+  const rootDir = process.cwd();
+  const schemaDir = path.join(rootDir, "schemas");
+  const artifacts: ArtifactDefinition[] = [
+    {
+      name: "metrics",
+      schemaPath: path.join(schemaDir, "metrics.v1.schema.json"),
+      artifactPath: path.join(rootDir, ".speckit", "metrics.json"),
+    },
+    {
+      name: "summary",
+      schemaPath: path.join(schemaDir, "summary.v1.schema.json"),
+      artifactPath: path.join(rootDir, ".speckit", "summary.json"),
+      optional: true,
+    },
+    {
+      name: "sanitizer report",
+      schemaPath: path.join(schemaDir, "sanitizer-report.v1.schema.json"),
+      artifactPath: path.join(rootDir, ".speckit", "sanitizer-report.json"),
+      optional: true,
+    },
+  ];
+
+  const ajv = new Ajv({
+    strict: false,
+    allErrors: true,
+  });
+  addFormats(ajv);
+
+  let failures = 0;
+
+  for (const artifact of artifacts) {
+    const exists = await fileExists(artifact.artifactPath);
+    if (!exists) {
+      if (!artifact.optional) {
+        console.warn(`[speckit] ${artifact.name} artifact not found at ${path.relative(rootDir, artifact.artifactPath)}`);
+        failures += 1;
+      } else {
+        console.log(`[speckit] Skipping ${artifact.name}: ${path.relative(rootDir, artifact.artifactPath)} not found.`);
+      }
+      continue;
+    }
+
+    const schema = await loadJson(artifact.schemaPath);
+    const validate = ajv.compile(schema);
+    const data = await loadJson(artifact.artifactPath);
+    const valid = validate(data);
+    if (!valid) {
+      failures += 1;
+      console.error(`[speckit] ${artifact.name} failed schema validation (${path.relative(rootDir, artifact.schemaPath)})`);
+      const details = formatErrors(validate.errors);
+      if (details) {
+        console.error(details);
+      }
+    } else {
+      console.log(`[speckit] ${artifact.name} validated against ${path.relative(rootDir, artifact.schemaPath)}`);
+    }
+  }
+
+  if (failures > 0) {
+    process.exitCode = 1;
+    throw new Error(`Artifact validation failed for ${failures} file${failures === 1 ? "" : "s"}.`);
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## Summary
- add JSON Schema definitions for metrics, summary, and sanitizer-report artifacts
- add an Ajv-based validator script and wire it into the speckit-analyze-run workflow
- document artifact schema contracts and compatibility guidance for contributors

## Testing
- `pnpm speckit:validate-artifacts`


------
https://chatgpt.com/codex/tasks/task_e_68d82a861b308324a2f793a55c37c7bc